### PR TITLE
Default UserGroup Getter for Radius proxy

### DIFF
--- a/src/MultiFactor.Radius.Adapter.Tests/UserGroupsGetterProviderTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/UserGroupsGetterProviderTests.cs
@@ -51,7 +51,7 @@ public class UserGroupsGetterProviderTests
     }
     
     [Fact]
-    public void Get_Radius_ShouldThrow()
+    public void Get_Radius_ShouldReturnDefaultGetter()
     {
         var host = TestHostFactory.CreateHost(services =>
         {
@@ -64,8 +64,8 @@ public class UserGroupsGetterProviderTests
         });
 
         var prov = host.Services.GetRequiredService<UserGroupsGetterProvider>();
-        var act = () => prov.GetUserGroupsGetter(AuthenticationSource.Radius);
+        var getter = prov.GetUserGroupsGetter(AuthenticationSource.Radius);
 
-        act.Should().Throw<NotImplementedException>();
+        getter.Should().NotBeNull().And.BeOfType<DefaultUserGroupsGetter>();
     }
 }

--- a/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/DefaultUserGroupsGetter.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/DefaultUserGroupsGetter.cs
@@ -14,7 +14,7 @@ namespace MultiFactor.Radius.Adapter.Services.Ldap.UserGroupsReading
 {
     public class DefaultUserGroupsGetter : IUserGroupsGetter
     {
-        public AuthenticationSource AuthenticationSource => AuthenticationSource.Ldap;
+        public AuthenticationSource AuthenticationSource => AuthenticationSource.Ldap | AuthenticationSource.Radius;
 
         public Task<string[]> GetAllUserGroupsAsync(IClientConfiguration clientConfig, ILdapConnectionAdapter adapter, string userDn)
         {


### PR DESCRIPTION
### Release 25.01.2024  |  Minor fixes  
#### Bugfixes
- Fixed: Default UserGroup Getter are used for Radius proxy