### PR TITLE
'ldap-catalog-type' option to set an implicit catalog service explicitly 

### DIFF
--- a/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/ad-auth-source-with-freeipa-catalog-type.config
+++ b/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/ad-auth-source-with-freeipa-catalog-type.config
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+	<configSections>
+		<section name="RadiusReply" type="MultiFactor.Radius.Adapter.RadiusReplyAttributesSection, multifactor-radius-adapter" />
+	</configSections>
+	
+	<appSettings>
+		<add key="radius-client-nas-identifier" value="windows"/>
+		<add key="radius-shared-secret" value="000"/>
+		<add key="first-factor-authentication-source" value="ActiveDirectory"/>
+		<add key="ldap-catalog-type" value="freeipa"/>
+		<add key="active-directory-domain" value="test.local"/>
+		<add key="adapter-client-endpoint" value="0.0.0.0"/>
+		<add key="nps-server-endpoint" value="127.0.0.1"/>
+		<add key="multifactor-nas-identifier" value="key"/>
+		<add key="multifactor-shared-secret" value="secret"/>
+	</appSettings>
+
+	<RadiusReply>
+		<Attributes>
+			<add name="Fortinet-Group-Name" value="Admins" when="UserGroup=VPN Admins" sufficient="true" />
+		</Attributes>
+	</RadiusReply>
+	
+</configuration>

--- a/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/ad-auth-source-without-catalog-type.config
+++ b/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/ad-auth-source-without-catalog-type.config
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+	<configSections>
+		<section name="RadiusReply" type="MultiFactor.Radius.Adapter.RadiusReplyAttributesSection, multifactor-radius-adapter" />
+	</configSections>
+	
+	<appSettings>
+		<add key="radius-client-nas-identifier" value="windows"/>
+		<add key="radius-shared-secret" value="000"/>
+		<add key="first-factor-authentication-source" value="ActiveDirectory"/>
+		<add key="active-directory-domain" value="test.local"/>
+		<add key="adapter-client-endpoint" value="0.0.0.0"/>
+		<add key="nps-server-endpoint" value="127.0.0.1"/>
+		<add key="multifactor-nas-identifier" value="key"/>
+		<add key="multifactor-shared-secret" value="secret"/>
+	</appSettings>
+
+	<RadiusReply>
+		<Attributes>
+			<add name="Fortinet-Group-Name" value="Admins" when="UserGroup=VPN Admins" sufficient="true" />
+		</Attributes>
+	</RadiusReply>
+	
+</configuration>

--- a/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/radius-auth-source-with-freeipa-catalog-type.config
+++ b/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/radius-auth-source-with-freeipa-catalog-type.config
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+	<configSections>
+		<section name="RadiusReply" type="MultiFactor.Radius.Adapter.RadiusReplyAttributesSection, multifactor-radius-adapter" />
+	</configSections>
+	
+	<appSettings>
+		<add key="radius-client-nas-identifier" value="windows"/>
+		<add key="radius-shared-secret" value="000"/>
+		<add key="first-factor-authentication-source" value="Radius"/>
+		<add key="ldap-catalog-type" value="FreeIpa"/>
+		<add key="adapter-client-endpoint" value="0.0.0.0"/>
+		<add key="nps-server-endpoint" value="127.0.0.1"/>
+		<add key="multifactor-nas-identifier" value="key"/>
+		<add key="multifactor-shared-secret" value="secret"/>
+	</appSettings>
+
+	<RadiusReply>
+		<Attributes>
+			<add name="Fortinet-Group-Name" value="Admins" when="UserGroup=VPN Admins" sufficient="true" />
+		</Attributes>
+	</RadiusReply>
+	
+</configuration>

--- a/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/radius-auth-source-with-openldap-catalog-type.config
+++ b/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/radius-auth-source-with-openldap-catalog-type.config
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+	<configSections>
+		<section name="RadiusReply" type="MultiFactor.Radius.Adapter.RadiusReplyAttributesSection, multifactor-radius-adapter" />
+	</configSections>
+	
+	<appSettings>
+		<add key="radius-client-nas-identifier" value="windows"/>
+		<add key="radius-shared-secret" value="000"/>
+		<add key="first-factor-authentication-source" value="Radius"/>
+		<add key="ldap-catalog-type" value="OpenLdap"/>
+		<add key="adapter-client-endpoint" value="0.0.0.0"/>
+		<add key="nps-server-endpoint" value="127.0.0.1"/>
+		<add key="multifactor-nas-identifier" value="key"/>
+		<add key="multifactor-shared-secret" value="secret"/>
+	</appSettings>
+
+	<RadiusReply>
+		<Attributes>
+			<add name="Fortinet-Group-Name" value="Admins" when="UserGroup=VPN Admins" sufficient="true" />
+		</Attributes>
+	</RadiusReply>
+	
+</configuration>

--- a/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/radius-auth-source-without-ldap-catalog-type.config
+++ b/src/MultiFactor.Radius.Adapter.Tests/Assets/clients/radius-auth-source-without-ldap-catalog-type.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+	<configSections>
+		<section name="RadiusReply" type="MultiFactor.Radius.Adapter.RadiusReplyAttributesSection, multifactor-radius-adapter" />
+	</configSections>
+	
+	<appSettings>
+		<add key="radius-client-nas-identifier" value="windows"/>
+		<add key="radius-shared-secret" value="000"/>
+		<add key="first-factor-authentication-source" value="Radius"/>
+		<add key="adapter-client-endpoint" value="0.0.0.0"/>
+		<add key="nps-server-endpoint" value="127.0.0.1"/>
+		<add key="multifactor-nas-identifier" value="key"/>
+		<add key="multifactor-shared-secret" value="secret"/>
+	</appSettings>
+
+	<RadiusReply>
+		<Attributes>
+			<add name="Fortinet-Group-Name" value="Admins" when="UserGroup=VPN Admins" sufficient="true" />
+		</Attributes>
+	</RadiusReply>
+	
+</configuration>

--- a/src/MultiFactor.Radius.Adapter.Tests/MultiFactor.Radius.Adapter.Tests.csproj
+++ b/src/MultiFactor.Radius.Adapter.Tests/MultiFactor.Radius.Adapter.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -131,13 +131,28 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Assets\clients\ad-auth-source-without-catalog-type.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Assets\clients\client-empty-identifier-and-ip.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\clients\ad-auth-source-with-freeipa-catalog-type.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\clients\radius-auth-source-with-openldap-catalog-type.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\clients\radius-auth-source-without-ldap-catalog-type.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Assets\clients\radius-reply-with-attribute.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Assets\clients\radius-reply-with-condition.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\clients\radius-auth-source-with-freeipa-catalog-type.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Assets\clients\radius-reply-with-sufficient.config">

--- a/src/MultiFactor.Radius.Adapter.Tests/UserGroupsGetterProviderTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/UserGroupsGetterProviderTests.cs
@@ -25,29 +25,31 @@ public class UserGroupsGetterProviderTests
     }
 
     [Theory]
-    [InlineData(AuthenticationSource.ActiveDirectory)]
-    [InlineData(AuthenticationSource.None)]
-    public void Get_ActiveDirectoryOrNone_ShouldReturnADGetter(AuthenticationSource source)
+    [InlineData(AuthenticationSource.ActiveDirectory, LdapCatalogType.ActiveDirectory)]
+    [InlineData(AuthenticationSource.Radius, LdapCatalogType.ActiveDirectory)]
+    public void Get_ActiveDirectoryOrNone_ShouldReturnADGetter(AuthenticationSource authenticationSource, LdapCatalogType ldapCatalog)
     {
         var host = CreateTestingHost();
 
         var prov = host.Services.GetRequiredService<UserGroupsGetterProvider>();
-        var getter = prov.GetUserGroupsGetter(source);
+        var getter = prov.GetUserGroupsGetter(authenticationSource, ldapCatalog);
 
         getter.Should().NotBeNull().And.BeOfType<ActiveDirectoryUserGroupsGetter>();
     }
     
     [Theory]
-    [InlineData(AuthenticationSource.Radius)]
-    [InlineData(AuthenticationSource.Ldap)]
-    [InlineData((AuthenticationSource)(-1))]
-    public void Get_LdapOrRadiusOrUnknown_ShouldReturnDefaultGetter(AuthenticationSource source)
+    [InlineData(AuthenticationSource.Radius, LdapCatalogType.OpenLdap)]
+    [InlineData(AuthenticationSource.Ldap, LdapCatalogType.ActiveDirectory)]
+    [InlineData(AuthenticationSource.ActiveDirectory, LdapCatalogType.FreeIpa)]
+    [InlineData((AuthenticationSource)(-1), LdapCatalogType.ActiveDirectory)]
+    public void Get_LdapOrRadiusOrUnknown_ShouldReturnDefaultGetter(AuthenticationSource authenticationSource, LdapCatalogType ldapCatalog)
     {
         var host = CreateTestingHost();
 
         var prov = host.Services.GetRequiredService<UserGroupsGetterProvider>();
-        var getter = prov.GetUserGroupsGetter(source);
+        var getter = prov.GetUserGroupsGetter(authenticationSource, ldapCatalog);
 
         getter.Should().NotBeNull().And.BeOfType<DefaultUserGroupsGetter>();
     }
+
 }

--- a/src/MultiFactor.Radius.Adapter/Configuration/ClientConfiguration.cs
+++ b/src/MultiFactor.Radius.Adapter/Configuration/ClientConfiguration.cs
@@ -142,7 +142,7 @@ namespace MultiFactor.Radius.Adapter.Configuration
         /// Network Policy Service RADIUS UDP Server endpoint
         /// </summary>
         public IPEndPoint NpsServerEndpoint { get; private set; }
-
+        public LdapCatalogType LdapCatalogType { get; private set; }
         public string ServiceAccountUser { get; private set; }
 
         public string ServiceAccountPassword { get; private set; }
@@ -328,6 +328,12 @@ namespace MultiFactor.Radius.Adapter.Configuration
         public IClientConfigurationBuilder SetNpsServerEndpoint(IPEndPoint val)
         {
             NpsServerEndpoint = val;
+            return this;
+        }
+
+        public IClientConfigurationBuilder SetLdapCatalogType(LdapCatalogType catalogType) 
+        {
+            LdapCatalogType = catalogType;
             return this;
         }
 

--- a/src/MultiFactor.Radius.Adapter/Configuration/Core/IClientConfiguration.cs
+++ b/src/MultiFactor.Radius.Adapter/Configuration/Core/IClientConfiguration.cs
@@ -19,6 +19,7 @@ namespace MultiFactor.Radius.Adapter.Configuration.Core
         string CallingStationIdVendorAttribute { get; }
         bool CheckMembership { get; }
         AuthenticationSource FirstFactorAuthenticationSource { get; }
+        LdapCatalogType LdapCatalogType { get; }
         string LdapBindDn { get; }
         bool LoadActiveDirectoryNestedGroups { get; }
         MultifactorApiCredential ApiCredential { get; }

--- a/src/MultiFactor.Radius.Adapter/Configuration/Core/IClientConfigurationBuilder.cs
+++ b/src/MultiFactor.Radius.Adapter/Configuration/Core/IClientConfigurationBuilder.cs
@@ -30,6 +30,7 @@ namespace MultiFactor.Radius.Adapter.Configuration.Core
         IClientConfigurationBuilder SetUseUpnAsIdentity(bool val);
         IClientConfigurationBuilder SetServiceClientEndpoint(IPEndPoint val);
         IClientConfigurationBuilder SetNpsServerEndpoint(IPEndPoint val);
+        IClientConfigurationBuilder SetLdapCatalogType(LdapCatalogType type);
         IClientConfigurationBuilder SetServiceAccountUser(string val);
         IClientConfigurationBuilder SetServiceAccountPassword(string val);
         IClientConfigurationBuilder SetSignUpGroups(string val);

--- a/src/MultiFactor.Radius.Adapter/Configuration/LdapCatalogType.cs
+++ b/src/MultiFactor.Radius.Adapter/Configuration/LdapCatalogType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace MultiFactor.Radius.Adapter.Configuration
+{
+    [Flags]
+    public enum LdapCatalogType
+    {
+        ActiveDirectory = 0,
+        OpenLdap = 1,
+        FreeIpa = 2,
+        Samba = 4
+    }
+}

--- a/src/MultiFactor.Radius.Adapter/Core/Ldap/IUserGroupsGetter.cs
+++ b/src/MultiFactor.Radius.Adapter/Core/Ldap/IUserGroupsGetter.cs
@@ -14,5 +14,6 @@ namespace MultiFactor.Radius.Adapter.Core.Ldap;
 public interface IUserGroupsGetter
 {
     AuthenticationSource AuthenticationSource { get; }
+    LdapCatalogType LdapCatalogType { get; }
     Task<string[]> GetAllUserGroupsAsync(IClientConfiguration clientConfig, ILdapConnectionAdapter connectionAdapter, string userDn);
 }

--- a/src/MultiFactor.Radius.Adapter/Core/Literals.cs
+++ b/src/MultiFactor.Radius.Adapter/Core/Literals.cs
@@ -39,6 +39,7 @@
             public const string UseActiveDirectoryMobileUserPhone = "use-active-directory-mobile-user-phone";
             public const string UseActiveDirectoryUserPhone = "use-active-directory-user-phone";
             public const string UseUpnAsIdentity = "use-upn-as-identity";
+            public const string LdapCatalogType = "ldap-catalog-type";
         }
     }
 }

--- a/src/MultiFactor.Radius.Adapter/HostedServices/ServerHost.cs
+++ b/src/MultiFactor.Radius.Adapter/HostedServices/ServerHost.cs
@@ -67,7 +67,7 @@ namespace MultiFactor.Radius.Adapter.HostedServices
 
         protected async Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)  
             {
                 //infinite job
                 await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);

--- a/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/ActiveDirectoryUserGroupsGetter.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/ActiveDirectoryUserGroupsGetter.cs
@@ -22,7 +22,8 @@ namespace MultiFactor.Radius.Adapter.Services.Ldap.UserGroupsReading
 {
     public class ActiveDirectoryUserGroupsGetter : IUserGroupsGetter
     {
-        public AuthenticationSource AuthenticationSource => AuthenticationSource.ActiveDirectory | AuthenticationSource.None;
+        public AuthenticationSource AuthenticationSource => AuthenticationSource.ActiveDirectory | AuthenticationSource.Radius | AuthenticationSource.None;
+        public LdapCatalogType LdapCatalogType => LdapCatalogType.ActiveDirectory;
 
         public async Task<string[]> GetAllUserGroupsAsync(IClientConfiguration clientConfig, ILdapConnectionAdapter adapter, string userDn)
         {

--- a/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/DefaultUserGroupsGetter.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/DefaultUserGroupsGetter.cs
@@ -15,7 +15,7 @@ namespace MultiFactor.Radius.Adapter.Services.Ldap.UserGroupsReading
     public class DefaultUserGroupsGetter : IUserGroupsGetter
     {
         public AuthenticationSource AuthenticationSource => AuthenticationSource.Ldap | AuthenticationSource.Radius;
-
+        public LdapCatalogType LdapCatalogType => ~LdapCatalogType.ActiveDirectory;
         public Task<string[]> GetAllUserGroupsAsync(IClientConfiguration clientConfig, ILdapConnectionAdapter adapter, string userDn)
         {
             return Task.FromResult<string[]>(Array.Empty<string>());

--- a/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/UserGroupsGetterProvider.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/UserGroupsGetterProvider.cs
@@ -20,9 +20,9 @@ namespace MultiFactor.Radius.Adapter.Services.Ldap.UserGroupsReading
             _defaultUserGroupsGetter = getters.Single(x => x.GetType() == typeof(DefaultUserGroupsGetter));
         }
 
-        public IUserGroupsGetter GetUserGroupsGetter(AuthenticationSource authSource)
+        public IUserGroupsGetter GetUserGroupsGetter(AuthenticationSource authSource, LdapCatalogType ldapCatalog)
         {
-            return _getters.FirstOrDefault(x => x.AuthenticationSource.HasFlag(authSource))
+            return _getters.FirstOrDefault(x => x.AuthenticationSource.HasFlag(authSource) && x.LdapCatalogType.HasFlag(ldapCatalog))
                 ?? _defaultUserGroupsGetter;
         }
     }

--- a/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/UserGroupsSource.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/UserGroupsSource.cs
@@ -22,7 +22,7 @@ namespace MultiFactor.Radius.Adapter.Services.Ldap.UserGroupsReading
 
         public async Task<string[]> GetUserGroupsAsync(IClientConfiguration clientConfig, ILdapConnectionAdapter connectionAdapter, string userDn)
         {
-            var getter = _provider.GetUserGroupsGetter(clientConfig.FirstFactorAuthenticationSource);
+            var getter = _provider.GetUserGroupsGetter(clientConfig.FirstFactorAuthenticationSource, clientConfig.LdapCatalogType);
             return await getter.GetAllUserGroupsAsync(clientConfig, connectionAdapter, userDn);
         }
     }


### PR DESCRIPTION
You can now use  'ldap-catalog-type' parameter to specify an implicit catalog service. It can be useful when you use non-LDAP Authentication Source, e.g. RADIUS NPS. You can set ActiveDirectory ldap catalog, so multifactor-radius-adapter will be able to resolve nested groups membership, since it requires to use AD-specific macros.

Config example:
```
<add key="ldap-catalog-type" value="freeipa"/>
```
Possible values are the following:
```
ActiveDirectory
OpenLdap 
FreeIpa
Samba
```