### PR TITLE
Ldap Attribute Pattern Matching Fix

### DIFF
--- a/src/MultiFactor.Radius.Adapter/Core/Radius/RadiusPacketParser.cs
+++ b/src/MultiFactor.Radius.Adapter/Core/Radius/RadiusPacketParser.cs
@@ -411,6 +411,11 @@ namespace MultiFactor.Radius.Adapter.Core.Radius
                     Array.Reverse(contentBytes);
                     return contentBytes;
 
+                case int _value:
+                    contentBytes = BitConverter.GetBytes(_value);
+                    Array.Reverse(contentBytes);
+                    return contentBytes;
+
                 case byte[] _value:
                     return _value;
 

--- a/src/MultiFactor.Radius.Adapter/Program.cs
+++ b/src/MultiFactor.Radius.Adapter/Program.cs
@@ -2,23 +2,24 @@
 using Microsoft.Extensions.Hosting;
 using MultiFactor.Radius.Adapter;
 using Serilog;
+using Serilog.Events;
 using System;
 using System.Text;
 
-var builder = Host.CreateApplicationBuilder(args);
-builder.ConfigureApplication();
-
-var host = builder.Build();
-
+IHost host = null;
 try
 {
+    var builder = Host.CreateApplicationBuilder(args);
+    builder.ConfigureApplication();
+
+    host = builder.Build();
     host.Run();
 }
 catch (Exception ex)
 {
     var errorMessage = FlattenException(ex);
 
-    if (Log.Logger != null)
+    if (Log.Logger != null && Log.IsEnabled(LogEventLevel.Error))
     {
         Log.Logger.Error($"Unable to start: {errorMessage}");
     }


### PR DESCRIPTION
### Ldap Attribute Type Matching Fix
#### Bugfixes
1. Fix type mismatch on a custom ldap attribute retrieving operation.
2. Enable console log in case of a startup-failed exception.