### PR TITLE
DEV-595

### DIFF
--- a/src/MultiFactor.Radius.Adapter/App.config
+++ b/src/MultiFactor.Radius.Adapter/App.config
@@ -6,7 +6,7 @@
 
     <!--Multifactor API -->
     <add key="multifactor-api-url" value="https://api.multifactor.ru"/>
-    <add key="multifactor-api-timeout" value="00:00:30"/>
+    <add key="multifactor-api-timeout" value="00:00:65"/>
 
     <!--HTTP proxy for API (optional)-->
     <!--<add key="multifactor-api-proxy" value="http://proxy:3128"/>-->

--- a/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/ActiveDirectoryUserGroupsGetter.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/ActiveDirectoryUserGroupsGetter.cs
@@ -14,7 +14,7 @@ namespace MultiFactor.Radius.Adapter.Services.Ldap.UserGroupsReading
 {
     public class ActiveDirectoryUserGroupsGetter : IUserGroupsGetter
     {
-        public AuthenticationSource AuthenticationSource => AuthenticationSource.ActiveDirectory | AuthenticationSource.None;
+        public AuthenticationSource AuthenticationSource => AuthenticationSource.ActiveDirectory | AuthenticationSource.None | AuthenticationSource.Radius;
 
         public async Task<string[]> GetUserGroupsFromContainerAsync(ILdapConnectionAdapter adapter, string baseDn, string userDn, bool loadNestedGroup)
         {

--- a/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/DefaultUserGroupsGetter.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/Ldap/UserGroupsReading/DefaultUserGroupsGetter.cs
@@ -11,7 +11,7 @@ namespace MultiFactor.Radius.Adapter.Services.Ldap.UserGroupsReading
 {
     public class DefaultUserGroupsGetter : IUserGroupsGetter
     {
-        public AuthenticationSource AuthenticationSource => AuthenticationSource.Ldap | AuthenticationSource.Radius;
+        public AuthenticationSource AuthenticationSource => AuthenticationSource.Ldap;
 
         public Task<string[]> GetUserGroupsFromContainerAsync(ILdapConnectionAdapter adapter, string baseDn, string userDn, bool loadNestedGroup)
         {


### PR DESCRIPTION
### Release 16.04.2025 | Nested groups search

#### Fixed

-   Fixed missing search for nested user groups when using RADIUS server as first factor.
-   The default value for the MF API in the configuration file was set to 65 seconds.