### PR TITLE
Feature/dev 356

### DIFF
--- a/src/MultiFactor.Radius.Adapter.Tests/AdapterConfig/ConfigurationLoadingTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/AdapterConfig/ConfigurationLoadingTests.cs
@@ -9,6 +9,7 @@ using System.Net;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.RootLevel;
 using MultiFactor.Radius.Adapter.Tests.Data.UsernameTransformationRules;
+using NetTools;
 
 namespace MultiFactor.Radius.Adapter.Tests.AdapterConfig;
 
@@ -996,5 +997,23 @@ public partial class ConfigurationLoadingTests
         var conf = host.Service<IServiceConfiguration>();
         var client = conf.GetClient(IPAddress.Parse("0.0.0.0"));
         Assert.Equal(TimeSpan.FromSeconds(30), client.LdapBindTimeout);
+    }
+    
+    [Fact]
+    [Trait("Category", "ip-white-list")]
+    public void IpWhiteList_ShouldSet()
+    {
+        var host = TestHostFactory.CreateHost(builder =>
+        {
+            builder.Services.Configure<TestConfigProviderOptions>(x =>
+            {
+                x.RootConfigFilePath = TestEnvironment.GetAssetPath("root-ip-white-list.config");
+            });
+        });
+
+        var conf = host.Service<IServiceConfiguration>();
+        var client = conf.GetClient(IPAddress.Parse("0.0.0.0"));
+        var expected = new[] { IPAddressRange.Parse("127.0.0.1/16"), IPAddressRange.Parse("126.0.0.1-127.0.0.3"), IPAddressRange.Parse("192.168.0.1") };
+        Assert.True(expected.SequenceEqual(client.IpWhiteAddressRanges));
     }
 }

--- a/src/MultiFactor.Radius.Adapter.Tests/Assets/root-ip-white-list.config
+++ b/src/MultiFactor.Radius.Adapter.Tests/Assets/root-ip-white-list.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <appSettings>
+        <add key="adapter-server-endpoint" value="0.0.0.0:1812"/>
+        <add key="radius-shared-secret" value="000"/>
+        <add key="multifactor-api-url" value="https://api.multifactor.dev"/>
+        <add key="first-factor-authentication-source" value="None"/>
+        <add key="multifactor-nas-identifier" value="key"/>
+        <add key="multifactor-shared-secret" value="secret"/>
+        <add key="logging-level" value="Debug"/>
+        <add key="ip-white-list" value="127.0.0.1/16; 126.0.0.1-127.0.0.3; 192.168.0.1"/>
+    </appSettings>
+</configuration>

--- a/src/MultiFactor.Radius.Adapter.Tests/AuthenticatedClientCacheConfigTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/AuthenticatedClientCacheConfigTests.cs
@@ -1,0 +1,35 @@
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.AuthenticatedClientCacheFeature;
+
+namespace MultiFactor.Radius.Adapter.Tests;
+
+public class AuthenticatedClientCacheConfigTests
+{
+    [Fact]
+    public void ShouldCreateConfigWithoutGroups()
+    {
+        var config = AuthenticatedClientCacheConfig.Create("10:10:00", true);
+        
+        Assert.NotNull(config);
+        Assert.Empty(config.AuthenticationCacheGroups);
+    }
+
+    [Fact]
+    public void SingleCacheGroup_ShouldCreateConfigWithGroup()
+    {
+        var config = AuthenticatedClientCacheConfig.Create("10:10:00", true, "group");
+        
+        Assert.NotNull(config);
+        Assert.Single(config.AuthenticationCacheGroups);
+        Assert.Equal("group", config.AuthenticationCacheGroups.First());
+    }
+    
+    [Fact]
+    public void MultipleCacheGroups_ShouldCreateConfigWithGroups()
+    {
+        var config = AuthenticatedClientCacheConfig.Create("10:10:00", true, "Group1;  GrouP2;     grOUp3");
+        
+        Assert.NotNull(config);
+        Assert.Equal(3, config.AuthenticationCacheGroups.Count);
+        Assert.True(config.AuthenticationCacheGroups.SequenceEqual(["group1", "group2", "group3"]));
+    }
+}

--- a/src/MultiFactor.Radius.Adapter.Tests/AuthenticatedClientCacheTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/AuthenticatedClientCacheTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.AuthenticatedClientCacheFeature;
+using MultiFactor.Radius.Adapter.Services;
+
+namespace MultiFactor.Radius.Adapter.Tests;
+
+public class AuthenticatedClientCacheTests
+{
+    [Fact]
+    public void NotMemberOfCacheGroups_ShouldReturnFalse()
+    {
+        var cache = new AuthenticatedClientCache(NullLogger<AuthenticatedClientCache>.Instance);
+        var clientConfig = new Mock<IClientConfiguration>();
+        var userGroups = new[] { "group3", "group4" };
+        var cacheConfig = AuthenticatedClientCacheConfig.Create("00:00:30", true, "group1;group2");
+        clientConfig.Setup(x => x.AuthenticationCacheLifetime).Returns(cacheConfig);
+        
+        var result = cache.TryHitCache("id", "userName", clientConfig.Object, userGroups);
+        
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void MemberOfCacheGroups_ShouldReturnTrue()
+    {
+        var cache = new AuthenticatedClientCache(NullLogger<AuthenticatedClientCache>.Instance);
+        var clientConfig = new Mock<IClientConfiguration>();
+        var userGroups = new[] { "group1", "group3" };
+        var cacheConfig = AuthenticatedClientCacheConfig.Create("10:10:00", true, "group1; group2");
+        clientConfig.Setup(x => x.AuthenticationCacheLifetime).Returns(cacheConfig);
+        clientConfig.Setup(x => x.Name).Returns("configName");
+        cache.SetCache("id", "userName", clientConfig.Object);
+        
+        var result = cache.TryHitCache("id", "userName", clientConfig.Object, userGroups);
+        
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void NoCacheGroups_ShouldReturnTrue()
+    {
+        var cache = new AuthenticatedClientCache(NullLogger<AuthenticatedClientCache>.Instance);
+        var clientConfig = new Mock<IClientConfiguration>();
+        var userGroups = new[] { "group1", "group2" };
+        var cacheConfig = AuthenticatedClientCacheConfig.Create("10:10:00", true);
+        clientConfig.Setup(x => x.AuthenticationCacheLifetime).Returns(cacheConfig);
+        clientConfig.Setup(x => x.Name).Returns("configName");
+        cache.SetCache("id", "userName", clientConfig.Object);
+        
+        var result = cache.TryHitCache("id", "userName", clientConfig.Object, userGroups);
+        
+        Assert.True(result);
+    }
+    
+    [Fact]
+    public void NoUserGroups_ShouldReturnFalse()
+    {
+        var cache = new AuthenticatedClientCache(NullLogger<AuthenticatedClientCache>.Instance);
+        var clientConfig = new Mock<IClientConfiguration>();
+        var userGroups = Array.Empty<string>();
+        var cacheConfig = AuthenticatedClientCacheConfig.Create("10:10:00", true, "group1; group2");
+        clientConfig.Setup(x => x.AuthenticationCacheLifetime).Returns(cacheConfig);
+        clientConfig.Setup(x => x.Name).Returns("configName");
+        cache.SetCache("id", "userName", clientConfig.Object);
+        
+        var result = cache.TryHitCache("id", "userName", clientConfig.Object, userGroups);
+        
+        Assert.False(result);
+    }
+}

--- a/src/MultiFactor.Radius.Adapter.Tests/MultiFactor.Radius.Adapter.Tests.csproj
+++ b/src/MultiFactor.Radius.Adapter.Tests/MultiFactor.Radius.Adapter.Tests.csproj
@@ -55,6 +55,8 @@
         <None Remove="Assets\root-invalid-ldap-bind-timeout.config" />
         <None Remove="Assets\root-no-ldap-bind-timeout.config"/>
         <None Remove="Assets\root-zero-ldap-bind-timeout.config"/>
+        <None Remove="Assets\root-ip-white-list.config"/>
+        
     </ItemGroup>
 
     <ItemGroup>
@@ -217,6 +219,9 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
         <Content Include="Assets\root-zero-ldap-bind-timeout.config">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="Assets\root-ip-white-list.config">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>

--- a/src/MultiFactor.Radius.Adapter.Tests/MultifactorApiAdapterTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/MultifactorApiAdapterTests.cs
@@ -75,7 +75,7 @@ namespace MultiFactor.Radius.Adapter.Tests
                 builder.Services.ReplaceService(api.Object);
                  
                 var cache = new Mock<IAuthenticatedClientCache>();
-                cache.Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IClientConfiguration>())).Returns(true);
+                cache.Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IClientConfiguration>(), It.IsAny<IReadOnlyCollection<string>>())).Returns(true);
                 builder.Services.ReplaceService(cache.Object);
             });
 
@@ -115,7 +115,7 @@ namespace MultiFactor.Radius.Adapter.Tests
                 builder.Services.ReplaceService(api.Object);
 
                 var cache = new Mock<IAuthenticatedClientCache>();
-                cache.Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IClientConfiguration>())).Returns(false);
+                cache.Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IClientConfiguration>(), It.IsAny<IReadOnlyCollection<string>>())).Returns(false);
                 builder.Services.ReplaceService(cache.Object);
             });
 

--- a/src/MultiFactor.Radius.Adapter.Tests/Pipeline/IpWhiteListMiddlewareTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/Pipeline/IpWhiteListMiddlewareTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MultiFactor.Radius.Adapter.Core.Framework.Context;
+using MultiFactor.Radius.Adapter.Core.Framework.Pipeline;
+using MultiFactor.Radius.Adapter.Core.Radius;
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.PreAuthModeFeature;
+using MultiFactor.Radius.Adapter.Server.Pipeline.IpWhiteList;
+using NetTools;
+
+namespace MultiFactor.Radius.Adapter.Tests.Pipeline;
+
+public class IpWhiteListMiddlewareTests
+{
+    [Fact]
+    public async Task EmptyWhiteList_ShouldInvokeNextMiddleware()
+    {
+        var middleware = new IpWhiteListMiddleware(NullLogger<IpWhiteListMiddleware>.Instance);
+
+        var context = CreateContext("127.0.0.1", []);
+        var next = new Mock<RadiusRequestDelegate>();
+        
+        await middleware.InvokeAsync(context, next.Object);
+        
+        next.Verify(q => q.Invoke(It.Is<RadiusContext>(x => x == context)), Times.Once);
+    }
+    
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("127.0.0.1/16")]
+    [InlineData("127.0.0.3/24")]
+    [InlineData("127.0.0.1-127.0.0.2")]
+    [InlineData("126.0.0.1-127.0.0.2")]
+    public async Task ClientIpInRange_ShouldInvokeNextMiddleware(string range)
+    {
+        var middleware = new IpWhiteListMiddleware(NullLogger<IpWhiteListMiddleware>.Instance);
+        var ips = range.Split(";", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var context = CreateContext("127.0.0.1", ips);
+        var next = new Mock<RadiusRequestDelegate>();
+        
+        await middleware.InvokeAsync(context, next.Object);
+        
+        next.Verify(q => q.Invoke(It.Is<RadiusContext>(x => x == context)), Times.Once);
+    }
+    
+    [Theory]
+    [InlineData("127.0.0.3")]
+    [InlineData("192.168.0.1/16")]
+    [InlineData("192.168.0.1/24")]
+    [InlineData("127.0.0.2-127.0.0.5")]
+    [InlineData("192.168.0.1-192.168.0.2")]
+    public async Task ClientIpNotInRange_ShouldTerminate(string range)
+    {
+        var middleware = new IpWhiteListMiddleware(NullLogger<IpWhiteListMiddleware>.Instance);
+        var ips = range.Split(";", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var context = CreateContext("127.0.0.1", ips);
+        var next = new Mock<RadiusRequestDelegate>();
+        
+        await middleware.InvokeAsync(context, next.Object);
+        
+        next.Verify(q => q.Invoke(It.Is<RadiusContext>(x => x == context)), Times.Never);
+        Assert.Equal(AuthenticationCode.Reject, context.Authentication.FirstFactor);
+        Assert.Equal(AuthenticationCode.Reject, context.Authentication.SecondFactor);
+    }
+    
+    private RadiusContext CreateContext(string clientIp, string[] ipWhiteList)
+    {
+        var packetMock = new Mock<IRadiusPacket>();
+        packetMock.Setup(x => x.TryGetUserPassword()).Returns(string.Empty);
+        var configMock = new Mock<IClientConfiguration>();
+        configMock.Setup(x => x.IpWhiteAddressRanges).Returns(ipWhiteList.Select(IPAddressRange.Parse).ToList());
+        configMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        var providerMock = new Mock<IServiceProvider>();
+        var context = new RadiusContext(packetMock.Object, configMock.Object, providerMock.Object);
+        context.RemoteEndpoint = IPEndPoint.Parse(clientIp);
+        return context;
+    }
+}

--- a/src/MultiFactor.Radius.Adapter.Tests/Pipeline/IpWhiteListMiddlewareTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/Pipeline/IpWhiteListMiddlewareTests.cs
@@ -64,10 +64,49 @@ public class IpWhiteListMiddlewareTests
         Assert.Equal(AuthenticationCode.Reject, context.Authentication.SecondFactor);
     }
     
-    private RadiusContext CreateContext(string clientIp, string[] ipWhiteList)
+    [Theory]
+    [InlineData("127.0.0.3")]
+    [InlineData("192.168.0.1/16")]
+    [InlineData("192.168.0.1/24")]
+    [InlineData("127.0.0.2-127.0.0.5")]
+    [InlineData("192.168.0.1-192.168.0.2")]
+    public async Task CallingStationIdNotInRange_ShouldTerminate(string range)
+    {
+        var middleware = new IpWhiteListMiddleware(NullLogger<IpWhiteListMiddleware>.Instance);
+        var ips = range.Split(";", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var context = CreateContext(clientIp: "127.0.0.3", ipWhiteList: ips, callingStationId: "127.0.0.1");
+        var next = new Mock<RadiusRequestDelegate>();
+        
+        await middleware.InvokeAsync(context, next.Object);
+        
+        next.Verify(q => q.Invoke(It.Is<RadiusContext>(x => x == context)), Times.Never);
+        Assert.Equal(AuthenticationCode.Reject, context.Authentication.FirstFactor);
+        Assert.Equal(AuthenticationCode.Reject, context.Authentication.SecondFactor);
+    }
+    
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("127.0.0.1/16")]
+    [InlineData("127.0.0.3/24")]
+    [InlineData("127.0.0.1-127.0.0.2")]
+    [InlineData("126.0.0.1-127.0.0.2")]
+    public async Task CallingStationIdInRange_ShouldInvokeNextMiddleware(string range)
+    {
+        var middleware = new IpWhiteListMiddleware(NullLogger<IpWhiteListMiddleware>.Instance);
+        var ips = range.Split(";", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var context = CreateContext(clientIp: "198.0.0.3", ips, callingStationId: "127.0.0.1");
+        var next = new Mock<RadiusRequestDelegate>();
+        
+        await middleware.InvokeAsync(context, next.Object);
+        
+        next.Verify(q => q.Invoke(It.Is<RadiusContext>(x => x == context)), Times.Once);
+    }
+    
+    private RadiusContext CreateContext(string clientIp, string[] ipWhiteList, string callingStationId = null)
     {
         var packetMock = new Mock<IRadiusPacket>();
         packetMock.Setup(x => x.TryGetUserPassword()).Returns(string.Empty);
+        packetMock.Setup(x => x.CallingStationId).Returns(callingStationId);
         var configMock = new Mock<IClientConfiguration>();
         configMock.Setup(x => x.IpWhiteAddressRanges).Returns(ipWhiteList.Select(IPAddressRange.Parse).ToList());
         configMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ClientLevel/ClientConfiguration.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ClientLevel/ClientConfiguration.cs
@@ -70,6 +70,7 @@ public class ClientConfiguration : IClientConfiguration
                    ActiveDirectory2FaGroup.Any() ||
                    ActiveDirectory2FaBypassGroup.Any() ||
                    PhoneAttributes.Any() ||
+                   AuthenticationCacheLifetime.AuthenticationCacheGroups.Any() ||
                    RadiusReplyAttributes
                        .Values
                        .SelectMany(attr => attr)

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ClientLevel/ClientConfiguration.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ClientLevel/ClientConfiguration.cs
@@ -8,12 +8,14 @@ using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.PreAuthMo
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.PrivacyModeFeature;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.RandomWaiterFeature;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.UserNameTransform;
+using NetTools;
 
 namespace MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
 
 public class ClientConfiguration : IClientConfiguration
 {
     private string _nestedGroupsBaseDn;
+    private readonly List<IPAddressRange> _ipAddressRanges = new List<IPAddressRange>();
 
     public ClientConfiguration(string name,
         string rdsSharedSecret,
@@ -195,6 +197,7 @@ public class ClientConfiguration : IClientConfiguration
     public PreAuthModeDescriptor PreAuthnMode { get; private set; } = PreAuthModeDescriptor.Default;
     public bool IsFreeIpa => !string.IsNullOrEmpty(LdapBindDn);
     public TimeSpan LdapBindTimeout => _ldapTimeout;
+    public IReadOnlyCollection<IPAddressRange> IpWhiteAddressRanges => _ipAddressRanges;
 
     public ClientConfiguration SetBypassSecondFactorWhenApiUnreachable(bool val)
     {
@@ -420,4 +423,6 @@ public class ClientConfiguration : IClientConfiguration
 
         return this;
     }
+    
+    public void AddWhiteIpRange(IPAddressRange range) => _ipAddressRanges.Add(range);
 }

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ClientLevel/IClientConfiguration.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ClientLevel/IClientConfiguration.cs
@@ -7,6 +7,7 @@ using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.PreAuthMo
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.PrivacyModeFeature;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.RandomWaiterFeature;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.UserNameTransform;
+using NetTools;
 
 namespace MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
 
@@ -44,4 +45,5 @@ public interface IClientConfiguration
     public TimeSpan LdapBindTimeout { get; }
     public bool ShouldLoadUserProfile { get; }
     public bool ShouldLoadUserGroups { get; }
+    public IReadOnlyCollection<IPAddressRange> IpWhiteAddressRanges { get; }
 }

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ConfigurationLoading/ClientConfigurationFactory.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ConfigurationLoading/ClientConfigurationFactory.cs
@@ -21,6 +21,7 @@ using MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.RootLevel;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Models.UserNameTransform;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.UserNameTransform;
+using NetTools;
 
 namespace MultiFactor.Radius.Adapter.Infrastructure.Configuration.ConfigurationLoading;
 
@@ -138,6 +139,8 @@ public class ClientConfigurationFactory
             builder.SetCallingStationIdVendorAttribute(callingStationIdAttr);
         }
 
+        ReadIpWhiteList(builder, appSettings.IpWhiteList);
+        
         return builder;
     }
 
@@ -431,6 +434,22 @@ public class ClientConfigurationFactory
         foreach (var attr in replyAttributes)
         {
             builder.AddRadiusReplyAttribute(attr.Key, attr.Value);
+        }
+    }
+
+    private void ReadIpWhiteList(ClientConfiguration builder, string ipWhiteList)
+    {
+        var splittedRanges = ipWhiteList
+            ?.Split([';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(x => x.ToLower())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? [];
+        
+        foreach (var range in splittedRanges)
+        {
+            if (!IPAddressRange.TryParse(range, out var ipAddressRange))
+                throw new InvalidConfigurationException($"Invalid IP address range: '{range}' in '{builder.Name}' config");
+            builder.AddWhiteIpRange(ipAddressRange);
         }
     }
 

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ConfigurationLoading/ClientConfigurationFactory.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ConfigurationLoading/ClientConfigurationFactory.cs
@@ -442,7 +442,7 @@ public class ClientConfigurationFactory
         var splittedRanges = ipWhiteList
             ?.Split([';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(x => x.ToLower())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct()
             .ToArray() ?? [];
         
         foreach (var range in splittedRanges)

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ConfigurationLoading/ClientConfigurationFactory.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/ConfigurationLoading/ClientConfigurationFactory.cs
@@ -380,7 +380,10 @@ public class ClientConfigurationFactory
     {
         try
         {
-            var ltConf = AuthenticatedClientCacheConfig.Create(appSettings.AuthenticationCacheLifetime, appSettings.AuthenticationCacheMinimalMatching);
+            var ltConf = AuthenticatedClientCacheConfig.Create(
+                appSettings.AuthenticationCacheLifetime,
+                appSettings.AuthenticationCacheMinimalMatching,
+                appSettings.AuthenticationCacheGroups);
             builder.SetAuthenticationCacheLifetime(ltConf);
         }
         catch

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/Features/AuthenticatedClientCacheFeature/AuthenticatedClientCacheConfig.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/Features/AuthenticatedClientCacheFeature/AuthenticatedClientCacheConfig.cs
@@ -30,7 +30,7 @@ public record AuthenticatedClientCacheConfig
         var groups = authenticationCacheGroups
             ?.Split([';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(x => x.ToLower())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct()
             .ToArray() ?? [];
         
         return new AuthenticatedClientCacheConfig(

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/Features/AuthenticatedClientCacheFeature/AuthenticatedClientCacheConfig.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/Features/AuthenticatedClientCacheFeature/AuthenticatedClientCacheConfig.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.AuthenticatedClientCacheFeature;
 
@@ -7,22 +9,33 @@ public record AuthenticatedClientCacheConfig
     public TimeSpan Lifetime { get; }
     public bool MinimalMatching { get; }
     public bool Enabled => Lifetime != TimeSpan.Zero;
+    public IReadOnlyCollection<string> AuthenticationCacheGroups { get; }
 
     public static AuthenticatedClientCacheConfig Default => new(TimeSpan.Zero, false);
 
-    public AuthenticatedClientCacheConfig(TimeSpan lifetime, bool minimalMatching)
+    public AuthenticatedClientCacheConfig(TimeSpan lifetime, bool minimalMatching, IReadOnlyCollection<string> authenticationCacheGroups = null)
     {
         Lifetime = lifetime;
         MinimalMatching = minimalMatching;
+        AuthenticationCacheGroups = authenticationCacheGroups?.Select(x => x.ToLower()).ToArray() ?? [];
     }
 
-    public static AuthenticatedClientCacheConfig Create(string value, bool minimalMatching)
+    public static AuthenticatedClientCacheConfig Create(string value, bool minimalMatching, string authenticationCacheGroups = null)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
             return Default;
         }
 
-        return new AuthenticatedClientCacheConfig(TimeSpan.ParseExact(value, @"hh\:mm\:ss", null, System.Globalization.TimeSpanStyles.None), minimalMatching);
+        var groups = authenticationCacheGroups
+            ?.Split([';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(x => x.ToLower())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? [];
+        
+        return new AuthenticatedClientCacheConfig(
+            TimeSpan.ParseExact(value, @"hh\:mm\:ss", null, System.Globalization.TimeSpanStyles.None),
+            minimalMatching,
+            groups);
     }
 }

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/Models/AppSettingsSection.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/Models/AppSettingsSection.cs
@@ -136,4 +136,7 @@ public class AppSettingsSection
     
     [Description("ldap-bind-timeout")]
     public string LdapBindTimeout { get; set; }
+    
+    [Description("ip-white-list")]
+    public string IpWhiteList { get; init; }
 }

--- a/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/Models/AppSettingsSection.cs
+++ b/src/MultiFactor.Radius.Adapter/Infrastructure/Configuration/Models/AppSettingsSection.cs
@@ -114,6 +114,9 @@ public class AppSettingsSection
     [Description("invalid-credential-delay")]
     public string InvalidCredentialDelay { get; init; }
 
+    [Description("authentication-cache-groups")]
+    public string AuthenticationCacheGroups { get; init; }
+
 
 
     [Description("logging-format")]

--- a/src/MultiFactor.Radius.Adapter/MultiFactor.Radius.Adapter.csproj
+++ b/src/MultiFactor.Radius.Adapter/MultiFactor.Radius.Adapter.csproj
@@ -35,7 +35,7 @@
 	<ItemGroup>
 		<PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.6.1" />
 		<PackageReference Include="FluentValidation" Version="11.9.0" />
-		<PackageReference Include="IPAddressRange" Version="6.0.0" />
+		<PackageReference Include="IPAddressRange" Version="6.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
 		<PackageReference Include="Serilog" Version="3.1.1" />

--- a/src/MultiFactor.Radius.Adapter/Program.cs
+++ b/src/MultiFactor.Radius.Adapter/Program.cs
@@ -20,10 +20,10 @@ try
     var builder = RadiusHost.CreateApplicationBuilder(args);
     builder.AddLogging();
     builder.ConfigureApplication();
-
-    builder.UseMiddleware<IpWhiteListMiddleware>();
+    
     builder.UseMiddleware<StatusServerMiddleware>();
     builder.UseMiddleware<AccessRequestFilterMiddleware>();
+    builder.UseMiddleware<IpWhiteListMiddleware>();
     builder.UseMiddleware<AccessChallengeMiddleware>();
     builder.UseMiddleware<AnonymousFirstFactorAuthenticationMiddleware>();
     builder.UseMiddleware<PreSecondFactorAuthenticationMiddleware>();

--- a/src/MultiFactor.Radius.Adapter/Program.cs
+++ b/src/MultiFactor.Radius.Adapter/Program.cs
@@ -11,6 +11,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using MultiFactor.Radius.Adapter.Infrastructure.Logging;
+using MultiFactor.Radius.Adapter.Server.Pipeline.IpWhiteList;
 
 IHost host = null;
 
@@ -20,6 +21,7 @@ try
     builder.AddLogging();
     builder.ConfigureApplication();
 
+    builder.UseMiddleware<IpWhiteListMiddleware>();
     builder.UseMiddleware<StatusServerMiddleware>();
     builder.UseMiddleware<AccessRequestFilterMiddleware>();
     builder.UseMiddleware<AccessChallengeMiddleware>();

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
@@ -64,10 +64,12 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
             {
                 var profile = context.Profile;
                 
-                if (profile?.Attributes.Has(context.Configuration.TwoFAIdentityAttribute) != true)
-                    profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute); 
-                
-                if (profile == null)
+                if (profile is null || !profile.Attributes.Has(context.Configuration.TwoFAIdentityAttribute))
+                {
+                    profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute);
+                }
+
+                if (profile is null)
                 {
                     _logger.LogWarning("User profile and attribute '{TwoFAIdentityAttribyte}' was not loaded", context.Configuration.TwoFAIdentityAttribute);
                     _logger.LogError("Failed to validate user profile.");

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
@@ -62,7 +62,11 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
 
             if (context.Configuration.UseIdentityAttribute)
             {
-                var profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute);
+                var profile = context.Profile;
+                
+                if (profile?.Attributes.Has(context.Configuration.TwoFAIdentityAttribute) != true)
+                    profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute); 
+                
                 if (profile == null)
                 {
                     _logger.LogWarning("User profile and attribute '{TwoFAIdentityAttribyte}' was not loaded", context.Configuration.TwoFAIdentityAttribute);

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/Processing/RadiusFirstFactorAuthenticationProcessor.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/Processing/RadiusFirstFactorAuthenticationProcessor.cs
@@ -50,7 +50,11 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication.P
 
             if (context.Configuration.UseIdentityAttribute)
             {
-                var profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute);
+                var profile = context.Profile;
+                
+                if (profile?.Attributes.Has(context.Configuration.TwoFAIdentityAttribute) != true)
+                    profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute); 
+                
                 if (profile == null)
                 {
                     _logger.LogWarning("Attribute '{TwoFAIdentityAttribyte}' was not loaded", context.Configuration.TwoFAIdentityAttribute);

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/Processing/RadiusFirstFactorAuthenticationProcessor.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/Processing/RadiusFirstFactorAuthenticationProcessor.cs
@@ -52,8 +52,10 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication.P
             {
                 var profile = context.Profile;
                 
-                if (profile?.Attributes.Has(context.Configuration.TwoFAIdentityAttribute) != true)
-                    profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute); 
+                if (profile is null || !profile.Attributes.Has(context.Configuration.TwoFAIdentityAttribute))
+                {
+                    profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute);
+                }
                 
                 if (profile == null)
                 {

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/IpWhiteList/IpWhiteListMiddleware.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/IpWhiteList/IpWhiteListMiddleware.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using MultiFactor.Radius.Adapter.Core.Framework.Context;
@@ -24,16 +25,22 @@ public class IpWhiteListMiddleware : IRadiusMiddleware
             return;
         }
         
-        var clientIp = context.RemoteEndpoint.Address;
+        var callingStationId = context.RequestPacket.CallingStationId;
+            
+        var clientIp =  IPAddress.TryParse(callingStationId ?? string.Empty, out var callingStationIp)
+            ? callingStationIp
+            : context.RemoteEndpoint.Address;
+        
         var isIpInRange = ipWhiteList.Any(x => x.Contains(clientIp));
-
+        var rangesStr = string.Join(", ", ipWhiteList);
+        
         if (isIpInRange)
         {
+            _logger.LogDebug("Client '{clientIp}' is in the allowed IP range: ({ranges})", clientIp.ToString(), rangesStr);
             await next(context);
             return;
         }
         
-        var rangesStr = string.Join(", ", ipWhiteList);
         _logger.LogDebug("Client '{clientIp}' is not in the allowed IP range: ({ranges})", clientIp.ToString(), rangesStr);
         
         context.SetFirstFactorAuth(AuthenticationCode.Reject);

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/IpWhiteList/IpWhiteListMiddleware.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/IpWhiteList/IpWhiteListMiddleware.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MultiFactor.Radius.Adapter.Core.Framework.Context;
+using MultiFactor.Radius.Adapter.Core.Framework.Pipeline;
+
+namespace MultiFactor.Radius.Adapter.Server.Pipeline.IpWhiteList;
+
+public class IpWhiteListMiddleware : IRadiusMiddleware
+{
+    private readonly ILogger<IpWhiteListMiddleware> _logger;
+    
+    public IpWhiteListMiddleware(ILogger<IpWhiteListMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(RadiusContext context, RadiusRequestDelegate next)
+    {
+        var ipWhiteList = context.Configuration.IpWhiteAddressRanges;
+        if (ipWhiteList.Count == 0)
+        { 
+            await next(context);
+            return;
+        }
+        
+        var clientIp = context.RemoteEndpoint.Address;
+        var isIpInRange = ipWhiteList.Any(x => x.Contains(clientIp));
+
+        if (isIpInRange)
+        {
+            await next(context);
+            return;
+        }
+        
+        var rangesStr = string.Join(", ", ipWhiteList);
+        _logger.LogDebug("Client '{clientIp}' is not in the allowed IP range: ({ranges})", clientIp.ToString(), rangesStr);
+        
+        context.SetFirstFactorAuth(AuthenticationCode.Reject);
+        context.SetSecondFactorAuth(AuthenticationCode.Reject);
+        context.Flags.Terminate();
+    }
+}

--- a/src/MultiFactor.Radius.Adapter/Services/AuthenticatedClientCache.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/AuthenticatedClientCache.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
-using MultiFactor.Radius.Adapter.Infrastructure.Configuration;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
 
 namespace MultiFactor.Radius.Adapter.Services
@@ -16,10 +17,22 @@ namespace MultiFactor.Radius.Adapter.Services
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public bool TryHitCache(string callingStationId, string userName, IClientConfiguration clientConfiguration)
+        public bool TryHitCache(string callingStationId, string userName, IClientConfiguration clientConfiguration, IReadOnlyCollection<string> userGroups)
         {
+            ArgumentNullException.ThrowIfNull(userGroups, nameof(userGroups));
             if (!clientConfiguration.AuthenticationCacheLifetime.Enabled) return false;
 
+            var cacheGroups = clientConfiguration.AuthenticationCacheLifetime.AuthenticationCacheGroups;
+            var lowercaseUserGroups = userGroups.Select(x => x.ToLower().Trim());
+            var groupsStr = string.Join(',', cacheGroups);
+            if (cacheGroups.Count > 0 && !cacheGroups.Intersect(lowercaseUserGroups).Any())
+            {
+                _logger.LogDebug("Skip auth caching. User '{userName}' is not a member of any authentication cache groups: ({groups})", userName, groupsStr);
+                return false;
+            }
+                
+            _logger.LogDebug("User '{userName}' is a member of authentication cache groups: ({groups})", userName, groupsStr);
+            
             if (!clientConfiguration.AuthenticationCacheLifetime.MinimalMatching && string.IsNullOrEmpty(callingStationId))
             {
                 _logger.LogWarning("Remote host parameter miss for user {userName:l}", userName);

--- a/src/MultiFactor.Radius.Adapter/Services/AuthenticatedClientCache.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/AuthenticatedClientCache.cs
@@ -30,9 +30,12 @@ namespace MultiFactor.Radius.Adapter.Services
                 _logger.LogDebug("Skip auth caching. User '{userName}' is not a member of any authentication cache groups: ({groups})", userName, groupsStr);
                 return false;
             }
-                
-            _logger.LogDebug("User '{userName}' is a member of authentication cache groups: ({groups})", userName, groupsStr);
-            
+
+            if (!string.IsNullOrEmpty(groupsStr))
+            {
+                _logger.LogDebug("User '{userName}' is a member of authentication cache groups: ({groups})", userName, groupsStr);
+            }
+
             if (!clientConfiguration.AuthenticationCacheLifetime.MinimalMatching && string.IsNullOrEmpty(callingStationId))
             {
                 _logger.LogWarning("Remote host parameter miss for user {userName:l}", userName);

--- a/src/MultiFactor.Radius.Adapter/Services/IAuthenticatedClientCache.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/IAuthenticatedClientCache.cs
@@ -1,4 +1,4 @@
-﻿using MultiFactor.Radius.Adapter.Infrastructure.Configuration;
+﻿using System.Collections.Generic;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
 
 namespace MultiFactor.Radius.Adapter.Services
@@ -6,6 +6,6 @@ namespace MultiFactor.Radius.Adapter.Services
     public interface IAuthenticatedClientCache
     {
         void SetCache(string callingStationId, string userName, IClientConfiguration clientConfiguration);
-        bool TryHitCache(string callingStationId, string userName, IClientConfiguration clientConfiguration);
+        bool TryHitCache(string callingStationId, string userName, IClientConfiguration clientConfiguration, IReadOnlyCollection<string> userGroups);
     }
 }

--- a/src/MultiFactor.Radius.Adapter/Services/MultiFactorApi/MultifactorApiAdapter.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/MultiFactorApi/MultifactorApiAdapter.cs
@@ -59,7 +59,7 @@ namespace MultiFactor.Radius.Adapter.Services.MultiFactorApi
             var calledStationId = context.RequestPacket.CalledStationId; //only for winlogon yet
             
             //try to get authenticated client to bypass second factor if configured
-            if (_authenticatedClientCache.TryHitCache(callingStationId, identity, context.Configuration))
+            if (_authenticatedClientCache.TryHitCache(callingStationId, identity, context.Configuration, context.Profile.MemberOf))
             {
                 _logger.LogInformation("Bypass second factor for user '{user:l}' with calling-station-id {csi:l} from {host:l}:{port}",
                     identity,


### PR DESCRIPTION
### Release 30.07.2025 | IP white list
#### New
- Added access control based on IP address. The setting allows connection to the adapter only from the specified IP\subnets. If the setting is empty or does not exist, all IP addresses are allowed.
Example:
	```
	<add key="ip-white-list" value="192.168.0.1; 127.0.0.1/16; 199.168.0.1-199.168.0.10"/>
	```
- Added a condition for caching the second factor based on user groups. If the user is a member of the specified groups, then his successful second factor will be cached. Setting works only together with setting ```authentication-cache-lifetime```.  If the setting is empty or does not exist, caching works for all users as normal.
Example:
	```
	<add key="authentication-cache-groups" value="Auth1;admins"/>
	```