### PR TITLE
DEV-531 Acct-Authentic

### DIFF
--- a/src/MultiFactor.Radius.Adapter.Tests/LdapFirstFactorAuthenticationProcessorTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/LdapFirstFactorAuthenticationProcessorTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MultiFactor.Radius.Adapter.Core.Framework.Context;
+using MultiFactor.Radius.Adapter.Core.Radius;
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.PreAuthModeFeature;
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.UserNameTransform;
+using MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication.Processing;
+using MultiFactor.Radius.Adapter.Services.Ldap;
+
+namespace MultiFactor.Radius.Adapter.Tests;
+
+public class LdapFirstFactorAuthenticationProcessorTests
+{
+        [Theory]
+        [InlineData(AccountType.Unknown)]
+        [InlineData(AccountType.Local)]
+        [InlineData(AccountType.Microsoft)]
+        public async Task WinLogonAccount_ShouldNotInvokeVerifyMembership(AccountType accountType)
+        {
+            var packetMock = new Mock<IRadiusPacket>();
+            packetMock.Setup(x => x.UserName).Returns("user");
+            packetMock.Setup(x => x.TryGetUserPassword()).Returns("password");
+            packetMock.Setup(x => x.AccountType).Returns(accountType);
+            var configMock = new Mock<IClientConfiguration>();
+            configMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+            configMock.Setup(x => x.SplittedActiveDirectoryDomains).Returns(new[]{"localhost"});
+            configMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+            var ldapServiceMock = new Mock<ILdapService>();
+            
+            var context = new RadiusContext(packetMock.Object, configMock.Object, new Mock<IServiceProvider>().Object);
+            
+            var processor = new LdapFirstFactorAuthenticationProcessor(ldapServiceMock.Object, NullLogger<LdapFirstFactorAuthenticationProcessor>.Instance);
+            await processor.ProcessFirstAuthFactorAsync(context);
+            ldapServiceMock.Verify(x => x.VerifyMembership(It.IsAny<string>(), It.IsAny<string>(),It.IsAny<string>(),It.IsAny<RadiusContext>()), Times.Never);
+        }
+        
+        [Fact]
+        public async Task WinLogonAccount_ShouldInvokeVerifyMembership()
+        {
+            var packetMock = new Mock<IRadiusPacket>();
+            packetMock.Setup(x => x.UserName).Returns("user");
+            packetMock.Setup(x => x.TryGetUserPassword()).Returns("password");
+            packetMock.Setup(x => x.AccountType).Returns(AccountType.Domain);
+            var configMock = new Mock<IClientConfiguration>();
+            configMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+            configMock.Setup(x => x.SplittedActiveDirectoryDomains).Returns(new[]{"localhost"});
+            configMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+            var ldapServiceMock = new Mock<ILdapService>();
+            
+            var context = new RadiusContext(packetMock.Object, configMock.Object, new Mock<IServiceProvider>().Object);
+            
+            var processor = new LdapFirstFactorAuthenticationProcessor(ldapServiceMock.Object, NullLogger<LdapFirstFactorAuthenticationProcessor>.Instance);
+            await processor.ProcessFirstAuthFactorAsync(context);
+            ldapServiceMock.Verify(x => x.VerifyMembership(It.IsAny<string>(), It.IsAny<string>(),It.IsAny<string>(),It.IsAny<RadiusContext>()), Times.Once);
+        }
+}

--- a/src/MultiFactor.Radius.Adapter.Tests/LdapFirstFactorAuthenticationProcessorTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/LdapFirstFactorAuthenticationProcessorTests.cs
@@ -36,12 +36,12 @@ public class LdapFirstFactorAuthenticationProcessorTests
         }
         
         [Fact]
-        public async Task WinLogonAccount_ShouldInvokeVerifyMembership()
+        public async Task WinLogonAccount_Domain_ShouldInvokeVerifyMembership()
         {
             var packetMock = new Mock<IRadiusPacket>();
             packetMock.Setup(x => x.UserName).Returns("user");
             packetMock.Setup(x => x.TryGetUserPassword()).Returns("password");
-            packetMock.Setup(x => x.AccountType).Returns(AccountType.Domain);
+            packetMock.Setup(x => x.AccountType).Returns(AccountType.Domain); 
             var configMock = new Mock<IClientConfiguration>();
             configMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
             configMock.Setup(x => x.SplittedActiveDirectoryDomains).Returns(new[]{"localhost"});

--- a/src/MultiFactor.Radius.Adapter.Tests/Pipeline/FirstFactorAuthenticationMiddlewareTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/Pipeline/FirstFactorAuthenticationMiddlewareTests.cs
@@ -6,9 +6,11 @@ using MultiFactor.Radius.Adapter.Core.Framework.Pipeline;
 using MultiFactor.Radius.Adapter.Core.Radius;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration;
 using MultiFactor.Radius.Adapter.Infrastructure.Configuration.ClientLevel;
+using MultiFactor.Radius.Adapter.Infrastructure.Configuration.Features.PreAuthModeFeature;
 using MultiFactor.Radius.Adapter.Server.Pipeline.AccessChallenge;
 using MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication;
 using MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication.Processing;
+using MultiFactor.Radius.Adapter.Services.Ldap.MembershipVerification;
 using MultiFactor.Radius.Adapter.Tests.Fixtures;
 using MultiFactor.Radius.Adapter.Tests.Fixtures.ConfigLoading;
 using MultiFactor.Radius.Adapter.Tests.Fixtures.Radius;
@@ -163,6 +165,77 @@ namespace MultiFactor.Radius.Adapter.Tests.Pipeline
             
             challengeProcessorProvider.Verify(x => x.GetChallengeProcessorByType(ChallengeType.PasswordChange), Times.Once);
             challengeProcessor.Verify(x => x.AddChallengeContext(It.IsAny<RadiusContext>()), Times.Once);
+        }
+        
+        [Fact]
+        public async Task Invoke_FirstFactorSourceIsNoneAndWinLogonAccount_ShouldInvokeVerifyMembership()
+        {
+            var processorMock = new Mock<IMembershipProcessor>();
+            processorMock
+                .Setup(x => x.ProcessMembershipAsync(It.IsAny<RadiusContext>()))
+                .ReturnsAsync(MembershipProcessingResult.Empty);
+            var host = TestHostFactory.CreateHost(builder =>
+            {
+                builder.Services.Configure<TestConfigProviderOptions>(x =>
+                {
+                    x.RootConfigFilePath = TestEnvironment.GetAssetPath("root-minimal-single.config");
+                });
+            
+                builder.UseMiddleware<AnonymousFirstFactorAuthenticationMiddleware>();
+                builder.InternalHostApplicationBuilder.Services.ReplaceService<IMembershipProcessor>(processorMock.Object);
+            });
+
+            var client = new Mock<IClientConfiguration>();
+            client.Setup(x => x.FirstFactorAuthenticationSource).Returns(AuthenticationSource.None);
+            client.Setup(x => x.ShouldLoadUserProfile).Returns(true);
+            client.Setup(x => x.ShouldLoadUserGroups).Returns(true);
+            client.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+            
+            var packetMock = new Mock<IRadiusPacket>();
+            packetMock.Setup(x => x.UserName).Returns("user");
+            packetMock.Setup(x => x.TryGetUserPassword()).Returns("password");
+            packetMock.Setup(x => x.AccountType).Returns(AccountType.Domain);
+            
+            var context = host.CreateContext(packetMock.Object, clientConfig: client.Object);
+            await host.InvokePipeline(context);
+
+            processorMock.Verify(x => x.ProcessMembershipAsync(It.IsAny<RadiusContext>()), Times.Once);
+        }
+        
+        [Theory]
+        [InlineData(AccountType.Unknown)]
+        [InlineData(AccountType.Local)]
+        [InlineData(AccountType.Microsoft)]
+        public async Task Invoke_FirstFactorSourceIsNoneAndWinLogonAccount_ShouldNotInvokeVerifyMembership(AccountType accountType)
+        {
+            var processorMock = new Mock<IMembershipProcessor>();
+            
+            var host = TestHostFactory.CreateHost(builder =>
+            {
+                builder.Services.Configure<TestConfigProviderOptions>(x =>
+                {
+                    x.RootConfigFilePath = TestEnvironment.GetAssetPath("root-minimal-single.config");
+                });
+            
+                builder.UseMiddleware<AnonymousFirstFactorAuthenticationMiddleware>();
+                builder.InternalHostApplicationBuilder.Services.ReplaceService<IMembershipProcessor>(processorMock.Object);
+            });
+
+            var client = new Mock<IClientConfiguration>();
+            client.Setup(x => x.FirstFactorAuthenticationSource).Returns(AuthenticationSource.None);
+            client.Setup(x => x.ShouldLoadUserProfile).Returns(true);
+            client.Setup(x => x.ShouldLoadUserGroups).Returns(true);
+            client.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+            
+            var packetMock = new Mock<IRadiusPacket>();
+            packetMock.Setup(x => x.UserName).Returns("user");
+            packetMock.Setup(x => x.TryGetUserPassword()).Returns("password");
+            packetMock.Setup(x => x.AccountType).Returns(accountType);
+            
+            var context = host.CreateContext(packetMock.Object, clientConfig: client.Object);
+            await host.InvokePipeline(context);
+
+            processorMock.Verify(x => x.ProcessMembershipAsync(It.IsAny<RadiusContext>()), Times.Never);
         }
     }
 }

--- a/src/MultiFactor.Radius.Adapter/Core/Framework/Context/RadiusContext.cs
+++ b/src/MultiFactor.Radius.Adapter/Core/Framework/Context/RadiusContext.cs
@@ -68,8 +68,21 @@ namespace MultiFactor.Radius.Adapter.Core.Framework.Context
         /// <summary>
         /// Should use for 2FA request to MFA API.
         /// </summary>
-        public string SecondFactorIdentity => Configuration.UseIdentityAttribute ? Profile.SecondFactorIdentity : UserName;
-
+        public string SecondFactorIdentity
+        {
+            get
+            {
+                if (!Configuration.UseIdentityAttribute)
+                    return UserName;
+                
+                var name = string.IsNullOrWhiteSpace(Profile.SecondFactorIdentity) && RequestPacket.AccountType != AccountType.Domain
+                    ? UserName
+                    : Profile.SecondFactorIdentity;
+                
+                return name;
+            }
+        }
+        
         /// <summary>
         /// memberof LDAP attribute value.
         /// </summary>

--- a/src/MultiFactor.Radius.Adapter/Core/Radius/IRadiusPacket.cs
+++ b/src/MultiFactor.Radius.Adapter/Core/Radius/IRadiusPacket.cs
@@ -76,5 +76,7 @@ namespace MultiFactor.Radius.Adapter.Core.Radius
         /// <param name="attribute"></param>
         /// <param name="transformedValue"></param>
         void AddTransformation(string attribute, string transformedValue);
+
+        AccountType AccountType { get; }
     }
 }

--- a/src/MultiFactor.Radius.Adapter/Core/Radius/RadiusPacket.cs
+++ b/src/MultiFactor.Radius.Adapter/Core/Radius/RadiusPacket.cs
@@ -105,6 +105,15 @@ namespace MultiFactor.Radius.Adapter.Core.Radius
         public string CallingStationId => GetCallingStationId();
         public string CalledStationId => IsWinLogon ? GetString("Called-Station-Id") : null;
         public string NasIdentifier => GetString("NAS-Identifier");
+        
+        public AccountType AccountType
+        {
+            get
+            {
+                var attrValue = AcctAuthentic ?? 0;
+                return UnintToAccountType(attrValue);
+            }
+        }
 
         public string TryGetUserPassword()
         {
@@ -326,5 +335,34 @@ namespace MultiFactor.Radius.Adapter.Core.Radius
 
             _transformMap[attribute] = transformedValue;
         }
+
+        private uint? AcctAuthentic
+        {
+            get
+            {
+                if (Attributes.TryGetValue("Acct-Authentic", out var values))
+                {
+                    return values.FirstOrDefault() as uint?;
+                }
+
+                return null;
+            }
+        }
+
+        private static AccountType UnintToAccountType(uint value) => value switch
+        {
+            1 => AccountType.Domain,
+            2 => AccountType.Local,
+            3 => AccountType.Microsoft,
+            _ => AccountType.Domain
+        };
+    }
+
+    public enum AccountType
+    {
+        Unknown = 0,
+        Domain = 1,
+        Local = 2,
+        Microsoft = 3
     }
 }

--- a/src/MultiFactor.Radius.Adapter/Core/Radius/RadiusPacket.cs
+++ b/src/MultiFactor.Radius.Adapter/Core/Radius/RadiusPacket.cs
@@ -111,7 +111,7 @@ namespace MultiFactor.Radius.Adapter.Core.Radius
             get
             {
                 var attrValue = AcctAuthentic ?? 0;
-                return UnintToAccountType(attrValue);
+                return UintToAccountType(attrValue);
             }
         }
 
@@ -349,7 +349,7 @@ namespace MultiFactor.Radius.Adapter.Core.Radius
             }
         }
 
-        private static AccountType UnintToAccountType(uint value) => value switch
+        private static AccountType UintToAccountType(uint value) => value switch
         {
             1 => AccountType.Domain,
             2 => AccountType.Local,

--- a/src/MultiFactor.Radius.Adapter/Extensions/RadiusHostApplicationBuilderExtensions.cs
+++ b/src/MultiFactor.Radius.Adapter/Extensions/RadiusHostApplicationBuilderExtensions.cs
@@ -41,7 +41,7 @@ internal static class RadiusHostApplicationBuilderExtensions
         builder.Services.AddSingleton<ProfileLoader>();
         builder.Services.AddSingleton<ILdapService, LdapService>();
         builder.Services.AddSingleton<MembershipVerifier>();
-        builder.Services.AddSingleton<MembershipProcessor>();
+        builder.Services.AddSingleton<IMembershipProcessor, MembershipProcessor>();
 
         builder.Services.AddSingleton<IAuthenticatedClientCache, AuthenticatedClientCache>();
 

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
@@ -15,10 +15,10 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
     /// </summary>
     public class AnonymousFirstFactorAuthenticationMiddleware : IRadiusMiddleware
     {
-        private readonly MembershipProcessor _membershipProcessor;
+        private readonly IMembershipProcessor _membershipProcessor;
         private readonly ILogger<AnonymousFirstFactorAuthenticationMiddleware> _logger;
 
-        public AnonymousFirstFactorAuthenticationMiddleware(MembershipProcessor membershipProcessor, 
+        public AnonymousFirstFactorAuthenticationMiddleware(IMembershipProcessor membershipProcessor, 
             ILogger<AnonymousFirstFactorAuthenticationMiddleware> logger)
         {
             _membershipProcessor = membershipProcessor;
@@ -32,48 +32,56 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
             var needFirstFactorAuth = context.Authentication.FirstFactor == AuthenticationCode.Awaiting;
             var needSecondFactorAuth = context.Authentication.SecondFactor == AuthenticationCode.Awaiting;
 
-            var shoulBeInvoked =
+            var shouldBeInvoked =
                 (isNoneFirstFactorSource && needFirstFactorAuth)
                 ||
                 (preAuthModeEnabled && needSecondFactorAuth);
 
-            if (!shoulBeInvoked)
+            if (!shouldBeInvoked)
             {
                 await next(context);
                 return;
             }
 
-            if (context.Configuration.ShouldLoadUserProfile || context.Configuration.ShouldLoadUserGroups)
+            if (context.RequestPacket.AccountType == AccountType.Domain)
             {
-                var result = await _membershipProcessor.ProcessMembershipAsync(context);
-                var handler = new MembershipProcessingResultHandler(result);
-
-                handler.EnrichContext(context);
-                var code = handler.GetDecision();
-
-                if (code != PacketCode.AccessAccept)
+                if (context.Configuration.ShouldLoadUserProfile || context.Configuration.ShouldLoadUserGroups)
                 {
-                    _logger.LogError("Failed to validate user profile.");
+                    var result = await _membershipProcessor.ProcessMembershipAsync(context);
+                    var handler = new MembershipProcessingResultHandler(result);
 
-                    context.SetFirstFactorAuth(AuthenticationCode.Reject);
-                    return;
+                    handler.EnrichContext(context);
+                    var code = handler.GetDecision();
+
+                    if (code != PacketCode.AccessAccept)
+                    {
+                        _logger.LogError("Failed to validate user profile.");
+
+                        context.SetFirstFactorAuth(AuthenticationCode.Reject);
+                        return;
+                    }
+                }
+
+                if (context.Configuration.UseIdentityAttribute)
+                {
+                    var profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute);
+                    if (profile == null)
+                    {
+                        _logger.LogWarning("User profile and attribute '{TwoFAIdentityAttribyte}' was not loaded",
+                            context.Configuration.TwoFAIdentityAttribute);
+                        _logger.LogError("Failed to validate user profile.");
+
+                        context.SetFirstFactorAuth(AuthenticationCode.Reject);
+                        return;
+                    }
+
+                    profile.SetIdentityAttribute(context.Configuration.TwoFAIdentityAttribute);
+                    context.UpdateProfile(profile);
                 }
             }
-
-            if (context.Configuration.UseIdentityAttribute)
+            else
             {
-                var profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute);
-                if (profile == null)
-                {
-                    _logger.LogWarning("User profile and attribute '{TwoFAIdentityAttribyte}' was not loaded", context.Configuration.TwoFAIdentityAttribute);
-                    _logger.LogError("Failed to validate user profile.");
-
-                    context.SetFirstFactorAuth(AuthenticationCode.Reject);
-                    return;
-                }
-
-                profile.SetIdentityAttribute(context.Configuration.TwoFAIdentityAttribute);
-                context.UpdateProfile(profile);
+                _logger.LogInformation("User '{user}' used '{accountType}' account to log in. Membership check is skipped.", context.UserName, context.RequestPacket.AccountType);
             }
 
             if (isNoneFirstFactorSource)

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
@@ -18,8 +18,7 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
         private readonly IMembershipProcessor _membershipProcessor;
         private readonly ILogger<AnonymousFirstFactorAuthenticationMiddleware> _logger;
 
-        public AnonymousFirstFactorAuthenticationMiddleware(IMembershipProcessor membershipProcessor, 
-            ILogger<AnonymousFirstFactorAuthenticationMiddleware> logger)
+        public AnonymousFirstFactorAuthenticationMiddleware(IMembershipProcessor membershipProcessor, ILogger<AnonymousFirstFactorAuthenticationMiddleware> logger)
         {
             _membershipProcessor = membershipProcessor;
             _logger = logger;
@@ -45,7 +44,9 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
 
             if (context.RequestPacket.AccountType != AccountType.Domain)
             {
-                _logger.LogInformation("User '{user}' used '{accountType}' account to log in. Membership check is skipped.", context.UserName, context.RequestPacket.AccountType);
+                _logger.LogInformation(
+                    "User '{user}' used '{accountType}' account to log in. Membership check is skipped.",
+                    context.UserName, context.RequestPacket.AccountType);
             }
             else
             {
@@ -66,19 +67,21 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
                     }
                 }
 
-            if (context.Configuration.UseIdentityAttribute)
-            {
-                var profile = context.Profile;
-                
-                if (profile is null || !profile.Attributes.Has(context.Configuration.TwoFAIdentityAttribute))
+                if (context.Configuration.UseIdentityAttribute)
                 {
-                    profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context, context.Configuration.TwoFAIdentityAttribute);
-                }
+                    var profile = context.Profile;
 
-                if (profile is null)
-                {
-                    _logger.LogWarning("User profile and attribute '{TwoFAIdentityAttribyte}' was not loaded", context.Configuration.TwoFAIdentityAttribute);
-                    _logger.LogError("Failed to validate user profile.");
+                    if (profile is null || !profile.Attributes.Has(context.Configuration.TwoFAIdentityAttribute))
+                    {
+                        profile = await _membershipProcessor.LoadProfileWithRequiredAttributeAsync(context,
+                            context.Configuration.TwoFAIdentityAttribute);
+                    }
+
+                    if (profile is null)
+                    {
+                        _logger.LogWarning("User profile and attribute '{TwoFAIdentityAttribyte}' was not loaded",
+                            context.Configuration.TwoFAIdentityAttribute);
+                        _logger.LogError("Failed to validate user profile.");
 
                         context.SetFirstFactorAuth(AuthenticationCode.Reject);
                         return;

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/AnonymousFirstFactorAuthenticationMiddleware.cs
@@ -43,7 +43,11 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
                 return;
             }
 
-            if (context.RequestPacket.AccountType == AccountType.Domain)
+            if (context.RequestPacket.AccountType != AccountType.Domain)
+            {
+                _logger.LogInformation("User '{user}' used '{accountType}' account to log in. Membership check is skipped.", context.UserName, context.RequestPacket.AccountType);
+            }
+            else
             {
                 if (context.Configuration.ShouldLoadUserProfile || context.Configuration.ShouldLoadUserGroups)
                 {
@@ -78,10 +82,6 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication
                     profile.SetIdentityAttribute(context.Configuration.TwoFAIdentityAttribute);
                     context.UpdateProfile(profile);
                 }
-            }
-            else
-            {
-                _logger.LogInformation("User '{user}' used '{accountType}' account to log in. Membership check is skipped.", context.UserName, context.RequestPacket.AccountType);
             }
 
             if (isNoneFirstFactorSource)

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/Processing/LdapFirstFactorAuthenticationProcessor.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/Processing/LdapFirstFactorAuthenticationProcessor.cs
@@ -56,6 +56,12 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication.P
                 try
                 {
                     await _ldapService.VerifyCredential(userName, password, ldapUri, context);
+                    if (context.RequestPacket.AccountType != AccountType.Domain)
+                    {
+                        _logger.LogInformation("User '{user}' used '{accountType}' account to log in. Membership check is skipped.", context.UserName, context.RequestPacket.AccountType);
+                        return PacketCode.AccessAccept;
+                    }
+                    
                     var isValid = await _ldapService.VerifyMembership(userName, password, ldapUri, context);
                     if (isValid)
                     {

--- a/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/Processing/RadiusFirstFactorAuthenticationProcessor.cs
+++ b/src/MultiFactor.Radius.Adapter/Server/Pipeline/FirstFactorAuthentication/Processing/RadiusFirstFactorAuthenticationProcessor.cs
@@ -19,11 +19,11 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication.P
     /// </summary>
     public class RadiusFirstFactorAuthenticationProcessor : IFirstFactorAuthenticationProcessor
     {
-        private readonly MembershipProcessor _membershipProcessor;
+        private readonly IMembershipProcessor _membershipProcessor;
         private readonly RadiusPacketParser _packetParser;
         private readonly ILogger<RadiusFirstFactorAuthenticationProcessor> _logger;
 
-        public RadiusFirstFactorAuthenticationProcessor(MembershipProcessor membershipProcessor,
+        public RadiusFirstFactorAuthenticationProcessor(IMembershipProcessor membershipProcessor,
             RadiusPacketParser packetParser,
             ILogger<RadiusFirstFactorAuthenticationProcessor> logger)
         {
@@ -39,6 +39,12 @@ namespace MultiFactor.Radius.Adapter.Server.Pipeline.FirstFactorAuthentication.P
             var code = await ProcessRadiusAuthAsync(context);
             if (code != PacketCode.AccessAccept) return code;
 
+            if (context.RequestPacket.AccountType != AccountType.Domain)
+            {
+                _logger.LogInformation("User '{user}' used '{accountType}' account to log in. Membership check is skipped.", context.UserName, context.RequestPacket.AccountType);
+                return code;
+            }
+            
             if (context.Configuration.ShouldLoadUserProfile || context.Configuration.ShouldLoadUserGroups)
             {
                 var result = await _membershipProcessor.ProcessMembershipAsync(context);

--- a/src/MultiFactor.Radius.Adapter/Services/Ldap/MembershipVerification/MembershipProcessor.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/Ldap/MembershipVerification/MembershipProcessor.cs
@@ -13,7 +13,13 @@ using System.Threading.Tasks;
 
 namespace MultiFactor.Radius.Adapter.Services.Ldap.MembershipVerification
 {
-    public class MembershipProcessor
+    public interface IMembershipProcessor
+    {
+        Task<MembershipProcessingResult> ProcessMembershipAsync(RadiusContext context);
+        Task<LdapProfile> LoadProfileWithRequiredAttributeAsync(RadiusContext context, string attr);
+    }
+
+    public class MembershipProcessor : IMembershipProcessor
     {
         private readonly ProfileLoader _profileLoader;
         private readonly MembershipVerifier _membershipVerifier;


### PR DESCRIPTION
### Release 04.08.2025 | Acct-Authentic attribute support for winlogon
#### New
- Added Acct-Authentic attribute support. If the RADIUS packet contains the Acct-Authentic attribute without a domain value, the adapter will skip loading the profile and checking groups membership. If there is no attribute in the packet, the adapter operates in normal mode.
The adapter interprets the attribute values as follows:
```
1 - Domain
2 - Local
3 - Microsoft
```