### PR TITLE
Feature/dev 343

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/AccessRequestAttributesTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/AccessRequestAttributesTests.cs
@@ -28,8 +28,8 @@ public class AccessRequestAttributesTests(RadiusFixtures radiusFixtures) : E2ETe
         var mfAPiMock = new Mock<IMultifactorApi>();
         AccessRequest? payload = null;
         mfAPiMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
-            .Callback((AccessRequest x, ApiCredential y) => payload = x)
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Callback((string a, AccessRequest x, ApiCredential y) => payload = x)
             .ReturnsAsync(new AccessRequestResponse() { Status = RequestStatus.Granted} );
 
         var hostConfiguration = (HostApplicationBuilder builder) =>
@@ -74,8 +74,8 @@ public class AccessRequestAttributesTests(RadiusFixtures radiusFixtures) : E2ETe
         var mfAPiMock = new Mock<IMultifactorApi>();
         AccessRequest? payload = null;
         mfAPiMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
-            .Callback((AccessRequest x, ApiCredential y) => payload = x)
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Callback((string a, AccessRequest x, ApiCredential y) => payload = x)
             .ReturnsAsync(new AccessRequestResponse() { Status = RequestStatus.Granted} );
 
         var hostConfiguration = (HostApplicationBuilder builder) =>

--- a/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/BypassWhenApiUnreachableTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/BypassWhenApiUnreachableTests.cs
@@ -87,7 +87,7 @@ public class BypassWhenApiUnreachableTests(RadiusFixtures radiusFixtures) : E2ET
         var secondFactorMock = new Mock<IMultifactorApi>();
 
         secondFactorMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ThrowsAsync(new MultifactorApiUnreachableException());
 
         var hostConfiguration = (HostApplicationBuilder builder) =>
@@ -120,7 +120,7 @@ public class BypassWhenApiUnreachableTests(RadiusFixtures radiusFixtures) : E2ET
         var secondFactorMock = new Mock<IMultifactorApi>();
 
         secondFactorMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ThrowsAsync(new MultifactorApiUnreachableException());
 
         var hostConfiguration = (HostApplicationBuilder builder) =>
@@ -153,7 +153,7 @@ public class BypassWhenApiUnreachableTests(RadiusFixtures radiusFixtures) : E2ET
         var secondFactorMock = new Mock<IMultifactorApi>();
 
         secondFactorMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ThrowsAsync(new MultifactorApiUnreachableException());
 
         var hostConfiguration = (HostApplicationBuilder builder) =>

--- a/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/ChangePasswordTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/ChangePasswordTests.cs
@@ -31,7 +31,7 @@ public class ChangePasswordTests(RadiusFixtures radiusFixtures) : E2ETestBase(ra
         var mfAPiMock = new Mock<IMultifactorApi>();
         
         mfAPiMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ReturnsAsync(new AccessRequestResponse() { Status = RequestStatus.Granted });
         
         var hostConfiguration = (HostApplicationBuilder builder) =>
@@ -74,7 +74,7 @@ public class ChangePasswordTests(RadiusFixtures radiusFixtures) : E2ETestBase(ra
         var mfAPiMock = new Mock<IMultifactorApi>();
         
         mfAPiMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ReturnsAsync(new AccessRequestResponse() { Status = RequestStatus.Granted });
         
         var hostConfiguration = (HostApplicationBuilder builder) =>

--- a/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ClientConfigurationFactoryTests/AppSettingsTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ClientConfigurationFactoryTests/AppSettingsTests.cs
@@ -21,6 +21,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -83,6 +84,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -147,6 +149,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -208,6 +211,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -241,6 +245,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -277,6 +282,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -312,6 +318,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -345,6 +352,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -378,6 +386,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = emptyString,
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -411,6 +420,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "nasIdentifier",
                 MultifactorSharedSecret = emptyString,
                 SignUpGroups = "groups",
@@ -445,6 +455,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "nasIdentifier",
                 MultifactorSharedSecret = "Secret",
                 SignUpGroups = "groups",
@@ -481,6 +492,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "nasIdentifier",
                 MultifactorSharedSecret = "Secret",
                 SignUpGroups = "groups",
@@ -516,6 +528,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "nasIdentifier",
                 MultifactorSharedSecret = "Secret",
                 SignUpGroups = groups,
@@ -554,6 +567,7 @@ public class AppSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "nasIdentifier",
                 MultifactorSharedSecret = "Secret",
                 SignUpGroups = "group",

--- a/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ClientConfigurationFactoryTests/LdapSettingsTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ClientConfigurationFactoryTests/LdapSettingsTests.cs
@@ -19,6 +19,7 @@ public class LdapSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -77,6 +78,7 @@ public class LdapSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -152,6 +154,7 @@ public class LdapSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -204,6 +207,7 @@ public class LdapSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -233,6 +237,7 @@ public class LdapSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -242,7 +247,7 @@ public class LdapSettingsTests
                 AdapterServerEndpoint = "127.0.0.1",
                 RadiusSharedSecret = "secret",
                 InvalidCredentialDelay = "3",
-                NpsServerEndpoint = "127.0.0.1"
+                NpsServerEndpoint = "127.0.0.1",
             },
             LdapServers = new LdapServersSection()
             {
@@ -275,6 +280,7 @@ public class LdapSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -284,7 +290,7 @@ public class LdapSettingsTests
                 AdapterServerEndpoint = "127.0.0.1",
                 RadiusSharedSecret = "secret",
                 InvalidCredentialDelay = "3",
-                NpsServerEndpoint = "127.0.0.1"
+                NpsServerEndpoint = "127.0.0.1",
             },
             LdapServers = new LdapServersSection()
             {
@@ -317,6 +323,7 @@ public class LdapSettingsTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 MultifactorNasIdentifier = "identifier",
                 MultifactorSharedSecret = "secret",
                 SignUpGroups = "groups",
@@ -326,7 +333,7 @@ public class LdapSettingsTests
                 AdapterServerEndpoint = "127.0.0.1",
                 RadiusSharedSecret = "secret",
                 InvalidCredentialDelay = "3",
-                NpsServerEndpoint = "127.0.0.1"
+                NpsServerEndpoint = "127.0.0.1",
             },
             LdapServers = new LdapServersSection()
             {

--- a/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ServiceConfigurationFactoryTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ServiceConfigurationFactoryTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Multifactor.Radius.Adapter.v2.Core;
 using Multifactor.Radius.Adapter.v2.Core.Configuration.Client;
 using Multifactor.Radius.Adapter.v2.Core.Configuration.Client.Build;
 using Multifactor.Radius.Adapter.v2.Core.Configuration.Service;
@@ -41,7 +42,7 @@ public class ServiceConfigurationFactoryTests
         var serviceConfiguration = serviceFactory.CreateConfig(GetConfiguration());
 
         Assert.NotNull(serviceConfiguration);
-        Assert.Equal("url", serviceConfiguration.ApiUrl);
+        Assert.Equal("url", serviceConfiguration.ApiUrls[0]);
         Assert.Equal("proxy", serviceConfiguration.ApiProxy);
         Assert.Equal(TimeSpan.FromMinutes(2), serviceConfiguration.ApiTimeout);
         Assert.True(serviceConfiguration.SingleClientMode);
@@ -58,6 +59,7 @@ public class ServiceConfigurationFactoryTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 RadiusClientNasIdentifier = "clientNasIdentifier1",
             }
         };
@@ -66,6 +68,7 @@ public class ServiceConfigurationFactoryTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 RadiusClientNasIdentifier = "clientNasIdentifier2",
             }
         };
@@ -96,7 +99,7 @@ public class ServiceConfigurationFactoryTests
         var serviceConfiguration = serviceFactory.CreateConfig(GetConfiguration());
 
         Assert.NotNull(serviceConfiguration);
-        Assert.Equal("url", serviceConfiguration.ApiUrl);
+        Assert.Equal("url", serviceConfiguration.ApiUrls[0]);
         Assert.Equal("proxy", serviceConfiguration.ApiProxy);
         Assert.Equal(TimeSpan.FromMinutes(2), serviceConfiguration.ApiTimeout);
         Assert.False(serviceConfiguration.SingleClientMode);
@@ -113,6 +116,7 @@ public class ServiceConfigurationFactoryTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 RadiusClientIp = "127.0.0.1",
             }
         };
@@ -121,6 +125,7 @@ public class ServiceConfigurationFactoryTests
         {
             AppSettings = new AppSettingsSection()
             {
+                MultifactorApiUrl = "http://127.0.0.1",
                 RadiusClientNasIdentifier = "127.0.0.2",
             }
         };
@@ -155,7 +160,7 @@ public class ServiceConfigurationFactoryTests
         var serviceConfiguration = serviceFactory.CreateConfig(GetConfiguration());
 
         Assert.NotNull(serviceConfiguration);
-        Assert.Equal("url", serviceConfiguration.ApiUrl);
+        Assert.Equal("url", serviceConfiguration.ApiUrls[0]);
         Assert.Equal("proxy", serviceConfiguration.ApiProxy);
         Assert.Equal(TimeSpan.FromMinutes(2), serviceConfiguration.ApiTimeout);
         Assert.False(serviceConfiguration.SingleClientMode);
@@ -163,12 +168,45 @@ public class ServiceConfigurationFactoryTests
         Assert.NotNull(serviceConfiguration.ServiceServerEndpoint);
         Assert.Equal(2, serviceConfiguration.Clients.Count);
     }
+    
+    [Theory]
+    [InlineData("url")]
+    [InlineData("url1;url2")]
+    [InlineData("url;url2;url3")]
+    public void CreateServiceConfiguration_MultipleMfApiUrls_ShouldCreate(string urls)
+    {
+        var clientConfigurationProviderMock = new Mock<IClientConfigurationsProvider>();
+        clientConfigurationProviderMock.Setup(x => x.GetClientConfigurations()).Returns([]);
+        var dictionaryMock = new Mock<IRadiusDictionary>();
+        var attribute = new DictionaryAttribute("name", 1, "type");
+        dictionaryMock.Setup(x => x.GetAttribute(It.IsAny<string>())).Returns(attribute);
 
-    private RadiusAdapterConfiguration GetConfiguration() => new RadiusAdapterConfiguration()
+        var clientFactoryMock = new Mock<IClientConfigurationFactory>();
+        clientFactoryMock
+            .Setup(
+                x => x.CreateConfig(
+                    It.IsAny<string>(),
+                    It.IsAny<RadiusAdapterConfiguration>(),
+                    It.IsAny<IServiceConfiguration>()))
+            .Returns(new Mock<IClientConfiguration>().Object);
+
+        var serviceFactory = new ServiceConfigurationFactory(
+            clientConfigurationProviderMock.Object,
+            clientFactoryMock.Object,
+            NullLogger<ServiceConfigurationFactory>.Instance);
+        var config = GetConfiguration(urls);
+        var serviceConfiguration = serviceFactory.CreateConfig(config);
+
+        var expectedUrls = Utils.SplitString(urls);
+        var actualUrls = serviceConfiguration.ApiUrls;
+        Assert.True(expectedUrls.SequenceEqual(actualUrls));
+    }
+
+    private RadiusAdapterConfiguration GetConfiguration(string apiUrls = "url") => new RadiusAdapterConfiguration()
     {
         AppSettings = new AppSettingsSection()
         {
-            MultifactorApiUrl = "url",
+            MultifactorApiUrl = apiUrls,
             MultifactorApiProxy = "proxy",
             MultifactorApiTimeout = "00:02:00",
             AdapterServerEndpoint = "127.0.0.1",

--- a/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ServiceConfigurationTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ServiceConfigurationTests.cs
@@ -29,9 +29,10 @@ public class ServiceConfigurationTests
     public void SetApiUrl_ShouldSet()
     {
         var configuration = new ServiceConfiguration();
-        configuration.SetApiUrl("url");
-
-        Assert.Equal("url", configuration.ApiUrl);
+        configuration.AddApiUrl("url");
+        Assert.Single(configuration.ApiUrls);
+        var apiUrl = configuration.ApiUrls[0];
+        Assert.Equal("url", apiUrl);
     }
 
     [Fact]

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/MultifactorApi/MultifactorApiServiceTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/MultifactorApi/MultifactorApiServiceTests.cs
@@ -43,7 +43,8 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.LdapServerConfiguration.PhoneAttributes).Returns([]);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns(identity);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
@@ -60,7 +61,8 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(true);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
-        
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
+
         var context = contextMock.Object;
         var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
         Assert.NotNull(response);
@@ -84,7 +86,8 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -104,11 +107,13 @@ public class MultifactorApiServiceTests
     {
         var apiMock = new Mock<IMultifactorApi>();
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        cacheMock.Setup(x => x.TryHitCache(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthenticatedClientCacheConfig>())).Returns(true);
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+        cacheMock.Setup(x => x.TryHitCache(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<AuthenticatedClientCacheConfig>())).Returns(true);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
 
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
-        
+
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(true);
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
@@ -120,13 +125,14 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.UserLdapProfile.Attributes).Returns([]);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
         contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
-        
+
         var context = contextMock.Object;
         var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
         Assert.NotNull(response);
@@ -143,12 +149,13 @@ public class MultifactorApiServiceTests
     {
         var apiMock = new Mock<IMultifactorApi>();
         apiMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ReturnsAsync(new AccessRequestResponse() { Status = status, Bypassed = bypass });
 
         var cacheMock = new Mock<IAuthenticatedClientCache>();
         cacheMock
-            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthenticatedClientCacheConfig>()))
+            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<AuthenticatedClientCacheConfig>()))
             .Returns(false);
         var service =
             new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
@@ -169,9 +176,11 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
-        
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
+
         var context = contextMock.Object;
         var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
         Assert.NotNull(response);
@@ -183,22 +192,24 @@ public class MultifactorApiServiceTests
     {
         var apiMock = new Mock<IMultifactorApi>();
         apiMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ThrowsAsync(new MultifactorApiUnreachableException());
 
         var cacheMock = new Mock<IAuthenticatedClientCache>();
         cacheMock
-            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthenticatedClientCacheConfig>()))
+            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<AuthenticatedClientCacheConfig>()))
             .Returns(false);
         var service =
             new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
 
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
-        
+
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(true);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
@@ -215,6 +226,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(false);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
 
         var context = contextMock.Object;
         var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
@@ -227,19 +239,21 @@ public class MultifactorApiServiceTests
     {
         var apiMock = new Mock<IMultifactorApi>();
         apiMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ThrowsAsync(new MultifactorApiUnreachableException());
 
         var cacheMock = new Mock<IAuthenticatedClientCache>();
         cacheMock
-            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthenticatedClientCacheConfig>()))
+            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<AuthenticatedClientCacheConfig>()))
             .Returns(false);
         var service =
             new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
 
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
@@ -256,6 +270,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(true);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
 
         var context = contextMock.Object;
         var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
@@ -268,12 +283,13 @@ public class MultifactorApiServiceTests
     {
         var apiMock = new Mock<IMultifactorApi>();
         apiMock
-            .Setup(x => x.CreateAccessRequest(It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()))
             .ThrowsAsync(new Exception());
 
         var cacheMock = new Mock<IAuthenticatedClientCache>();
         cacheMock
-            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthenticatedClientCacheConfig>()))
+            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<AuthenticatedClientCacheConfig>()))
             .Returns(false);
         var service =
             new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
@@ -295,12 +311,258 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(true);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
         var context = contextMock.Object;
         var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
         Assert.NotNull(response);
         Assert.Equal(AuthenticationStatus.Reject, response.Code);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CreateSecondFactorRequestAsync_MultipleUrlsWithUnreachableUrl_ShouldAccept(bool bypass)
+    {
+        // Arrange
+        var brokenUrl = "broken-url.com";
+        var mfUrl = "mf-url.dev";
+        var apiMock = new Mock<IMultifactorApi>();
+        apiMock
+            .Setup(x => x.CreateAccessRequest(It.Is<string>(u => u == brokenUrl), It.IsAny<AccessRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<MultifactorApiUnreachableException>();
+
+        apiMock
+            .Setup(x => x.CreateAccessRequest(It.Is<string>(u => u == mfUrl), It.IsAny<AccessRequest>(),
+                It.IsAny<ApiCredential>()))
+            .ReturnsAsync(new AccessRequestResponse() { Status = RequestStatus.Granted });
+
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+        cacheMock
+            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<AuthenticatedClientCacheConfig>()))
+            .Returns(false);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket.TryGetChallenge()).Returns(() => null);
+        contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
+        contextMock.Setup(x => x.RequestPacket.CallingStationIdAttribute).Returns("CallingStationIdAttribute");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.UserLdapProfile.Attributes).Returns([]);
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
+        contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
+        contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(bypass);
+
+        var context = contextMock.Object;
+
+        // Act
+        var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Accept, response.Code);
+        apiMock.Verify(
+            x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task CreateSecondFactorRequestAsync_MultipleUrlsWithAllUnreachableUrls_ShouldReject()
+    {
+        // Arrange
+        var brokenUrl = "broken-url.com";
+        var mfUrl = "mf-url.dev";
+        var apiMock = new Mock<IMultifactorApi>();
+        apiMock
+            .Setup(x => x.CreateAccessRequest(It.Is<string>(u => u == brokenUrl), It.IsAny<AccessRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<MultifactorApiUnreachableException>();
+
+        apiMock
+            .Setup(x => x.CreateAccessRequest(It.Is<string>(u => u == mfUrl), It.IsAny<AccessRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<MultifactorApiUnreachableException>();
+
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+        cacheMock
+            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<AuthenticatedClientCacheConfig>()))
+            .Returns(false);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket.TryGetChallenge()).Returns(() => null);
+        contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
+        contextMock.Setup(x => x.RequestPacket.CallingStationIdAttribute).Returns("CallingStationIdAttribute");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.UserLdapProfile.Attributes).Returns([]);
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
+        contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
+        contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(false);
+
+        var context = contextMock.Object;
+
+        // Act
+        var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Reject, response.Code);
+        apiMock.Verify(
+            x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task CreateSecondFactorRequestAsync_MultipleUrlsWithException_ShouldReject()
+    {
+        // Arrange
+        var brokenUrl = "broken-url.com";
+        var mfUrl = "mf-url.dev";
+        var apiMock = new Mock<IMultifactorApi>();
+        apiMock
+            .Setup(x => x.CreateAccessRequest(It.Is<string>(u => u == brokenUrl), It.IsAny<AccessRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<Exception>();
+
+        apiMock
+            .Setup(x => x.CreateAccessRequest(It.Is<string>(u => u == mfUrl), It.IsAny<AccessRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<Exception>();
+
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+        cacheMock
+            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<AuthenticatedClientCacheConfig>()))
+            .Returns(false);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket.TryGetChallenge()).Returns(() => null);
+        contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
+        contextMock.Setup(x => x.RequestPacket.CallingStationIdAttribute).Returns("CallingStationIdAttribute");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.UserLdapProfile.Attributes).Returns([]);
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
+        contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
+        contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(false);
+
+        var context = contextMock.Object;
+
+        // Act
+        var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Reject, response.Code);
+        apiMock.Verify(
+            x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()),
+            Times.Exactly(2));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CreateSecondFactorRequestAsync_MultipleUrlsFirstResponse_ShouldAccept(bool bypass)
+    {
+        // Arrange
+        var brokenUrl = "broken-url.com";
+        var mfUrl = "mf-url.dev";
+        var apiMock = new Mock<IMultifactorApi>();
+        apiMock
+            .Setup(x => x.CreateAccessRequest(It.Is<string>(u => u == brokenUrl), It.IsAny<AccessRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<Exception>();
+
+        apiMock
+            .Setup(x => x.CreateAccessRequest(It.Is<string>(u => u == mfUrl), It.IsAny<AccessRequest>(),
+                It.IsAny<ApiCredential>()))
+            .ReturnsAsync(new AccessRequestResponse() { Status = RequestStatus.Granted });
+
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+        cacheMock
+            .Setup(x => x.TryHitCache(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<AuthenticatedClientCacheConfig>()))
+            .Returns(false);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket.TryGetChallenge()).Returns(() => null);
+        contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
+        contextMock.Setup(x => x.RequestPacket.CallingStationIdAttribute).Returns("CallingStationIdAttribute");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.UserLdapProfile.Attributes).Returns([]);
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
+        contextMock.Setup(x => x.ApiUrls).Returns([mfUrl, brokenUrl]);
+        contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(bypass);
+
+        var context = contextMock.Object;
+
+        // Act
+        var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Accept, response.Code);
+        apiMock.Verify(
+            x => x.CreateAccessRequest(It.IsAny<string>(), It.IsAny<AccessRequest>(), It.IsAny<ApiCredential>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -308,63 +570,73 @@ public class MultifactorApiServiceTests
     {
         var apiMock = new Mock<IMultifactorApi>();
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => service.SendChallengeAsync(null));
     }
-    
+
     [Theory]
     [ClassData(typeof(EmptyStringsListInput))]
     public async Task SendChallenge_NoAnswer_ShouldThrowException(string answer)
     {
         var apiMock = new Mock<IMultifactorApi>();
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
         var context = new Mock<IRadiusPipelineExecutionContext>().Object;
-        await Assert.ThrowsAnyAsync<ArgumentException>(() => service.SendChallengeAsync(new SendChallengeRequest(context, answer, "requestId")));
+        await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+            service.SendChallengeAsync(new SendChallengeRequest(context, answer, "requestId")));
     }
-    
+
     [Theory]
     [ClassData(typeof(EmptyStringsListInput))]
     public async Task SendChallenge_NoRequestId_ShouldThrowException(string requestId)
     {
         var apiMock = new Mock<IMultifactorApi>();
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
         var context = new Mock<IRadiusPipelineExecutionContext>().Object;
-        await Assert.ThrowsAnyAsync<ArgumentException>(() => service.SendChallengeAsync(new SendChallengeRequest(context, "answer", requestId)));
+        await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+            service.SendChallengeAsync(new SendChallengeRequest(context, "answer", requestId)));
     }
-    
+
     [Theory]
     [ClassData(typeof(EmptyStringsListInput))]
     public async Task SendChallenge_NoIdentity_ShouldThrow(string identity)
     {
         var apiMock = new Mock<IMultifactorApi>();
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
-        
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(false);
         contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
-        
+
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(identity);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns(identity);
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
         var context = contextMock.Object;
-        await Assert.ThrowsAnyAsync<InvalidOperationException>(() => service.SendChallengeAsync(new SendChallengeRequest(context, "answer", "requestId")));
+        await Assert.ThrowsAnyAsync<InvalidOperationException>(() =>
+            service.SendChallengeAsync(new SendChallengeRequest(context, "answer", "requestId")));
     }
-    
+
     [Theory]
     [ClassData(typeof(EmptyStringsListInput))]
     public async Task SendChallenge_EmptyIdentityAttributeValue_ShouldThrow(string identity)
     {
         var apiMock = new Mock<IMultifactorApi>();
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
-        
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
         contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
@@ -374,33 +646,40 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
         contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns("test");
-        contextMock.Setup(x => x.UserLdapProfile.Attributes).Returns([new LdapAttribute(new LdapAttributeName("test"), [identity])]);
-        
+        contextMock.Setup(x => x.UserLdapProfile.Attributes)
+            .Returns([new LdapAttribute(new LdapAttributeName("test"), [identity])]);
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
+
         var context = contextMock.Object;
-        await Assert.ThrowsAnyAsync<InvalidOperationException>(() => service.SendChallengeAsync(new SendChallengeRequest(context, "answer", "requestId")));
+        await Assert.ThrowsAnyAsync<InvalidOperationException>(() =>
+            service.SendChallengeAsync(new SendChallengeRequest(context, "answer", "requestId")));
     }
 
     [Theory]
     [InlineData(RequestStatus.Denied, AuthenticationStatus.Reject)]
-    [InlineData(RequestStatus.Granted,  AuthenticationStatus.Accept)]
-    [InlineData(RequestStatus.Granted,  AuthenticationStatus.Bypass, true)]
+    [InlineData(RequestStatus.Granted, AuthenticationStatus.Accept)]
+    [InlineData(RequestStatus.Granted, AuthenticationStatus.Bypass, true)]
     [InlineData(RequestStatus.AwaitingAuthentication, AuthenticationStatus.Awaiting)]
-    public async Task SendChallenge_ShouldReturnResponseCode(RequestStatus requestStatus, AuthenticationStatus expectedStatus, bool bypassed = false)
+    public async Task SendChallenge_ShouldReturnResponseCode(RequestStatus requestStatus,
+        AuthenticationStatus expectedStatus, bool bypassed = false)
     {
         var apiMock = new Mock<IMultifactorApi>();
         apiMock
-            .Setup(x => x.SendChallengeAsync(It.IsAny<ChallengeRequest>(), It.IsAny<ApiCredential>()))
-            .ReturnsAsync(() => new AccessRequestResponse() { Status = requestStatus, Bypassed = bypassed});
+            .Setup(x => x.SendChallengeAsync(It.IsAny<string>(), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .ReturnsAsync(() => new AccessRequestResponse() { Status = requestStatus, Bypassed = bypassed });
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
-        
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
         contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
@@ -410,17 +689,20 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
         contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
-        
+
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
-        
-        var response = await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
+
+        var response =
+            await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
         Assert.NotNull(response);
         Assert.Equal(expectedStatus, response.Code);
     }
@@ -430,13 +712,16 @@ public class MultifactorApiServiceTests
     {
         var apiMock = new Mock<IMultifactorApi>();
         apiMock
-            .Setup(x => x.SendChallengeAsync(It.IsAny<ChallengeRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.SendChallengeAsync(It.IsAny<string>(), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
             .ThrowsAsync(new MultifactorApiUnreachableException());
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
-        
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
@@ -444,24 +729,29 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(false);
         contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
-        
-        var response = await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
+
+        var response =
+            await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
         Assert.NotNull(response);
         Assert.Equal(AuthenticationStatus.Reject, response.Code);
     }
-    
+
     [Fact]
     public async Task SendChallenge_MultifactorApiUnreachableExceptionBypass_ShouldReturnBypass()
     {
         var apiMock = new Mock<IMultifactorApi>();
         apiMock
-            .Setup(x => x.SendChallengeAsync(It.IsAny<ChallengeRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.SendChallengeAsync(It.IsAny<string>(), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
             .ThrowsAsync(new MultifactorApiUnreachableException());
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
-        
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
@@ -469,24 +759,29 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(true);
         contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
-        
-        var response = await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
+
+        var response =
+            await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
         Assert.NotNull(response);
         Assert.Equal(AuthenticationStatus.Bypass, response.Code);
     }
-    
+
     [Fact]
     public async Task SendChallenge_Exception_ShouldReturnReject()
     {
         var apiMock = new Mock<IMultifactorApi>();
         apiMock
-            .Setup(x => x.SendChallengeAsync(It.IsAny<ChallengeRequest>(), It.IsAny<ApiCredential>()))
+            .Setup(x => x.SendChallengeAsync(It.IsAny<string>(), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
             .ThrowsAsync(new Exception());
         var cacheMock = new Mock<IAuthenticatedClientCache>();
-        var service = new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
-        
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
@@ -494,9 +789,232 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(true);
         contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
-        
-        var response = await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
+        contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
+
+        var response =
+            await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
         Assert.NotNull(response);
         Assert.Equal(AuthenticationStatus.Reject, response.Code);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SendChallenge_MultipleUrlsWithUnreachableUrl_ShouldAccept(bool bypass)
+    {
+        // Arrange
+        var brokenUrl = "broken-url.com";
+        var mfUrl = "mf-url.dev";
+        var apiMock = new Mock<IMultifactorApi>();
+        apiMock
+            .Setup(x => x.SendChallengeAsync(It.Is<string>(u => u == brokenUrl), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<MultifactorApiUnreachableException>();
+
+        apiMock
+            .Setup(x => x.SendChallengeAsync(It.Is<string>(u => u == mfUrl), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .ReturnsAsync(() => new AccessRequestResponse() { Status = RequestStatus.Granted });
+
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
+        contextMock.Setup(x => x.RequestPacket.CallingStationIdAttribute).Returns("CallingStationIdAttribute");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(bypass);
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
+        contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
+
+        var response =
+            await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Accept, response.Code);
+        apiMock.Verify(
+            x => x.SendChallengeAsync(It.IsAny<string>(), It.IsAny<ChallengeRequest>(), It.IsAny<ApiCredential>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task SendChallenge_MultipleUrlsWithAllUnreachableUrls_ShouldReject()
+    {
+        // Arrange
+        var brokenUrl = "broken-url.com";
+        var mfUrl = "mf-url.dev";
+        var apiMock = new Mock<IMultifactorApi>();
+        apiMock
+            .Setup(x => x.SendChallengeAsync(It.Is<string>(u => u == brokenUrl), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<MultifactorApiUnreachableException>();
+
+        apiMock
+            .Setup(x => x.SendChallengeAsync(It.Is<string>(u => u == mfUrl), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<MultifactorApiUnreachableException>();
+
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
+        contextMock.Setup(x => x.RequestPacket.CallingStationIdAttribute).Returns("CallingStationIdAttribute");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
+        contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
+
+        // Act
+        var response =
+            await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Reject, response.Code);
+        apiMock.Verify(
+            x => x.SendChallengeAsync(It.IsAny<string>(), It.IsAny<ChallengeRequest>(), It.IsAny<ApiCredential>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task SendChallenge_MultipleUrlsWithException_ShouldReject()
+    {
+        // Arrange
+        var brokenUrl = "broken-url.com";
+        var mfUrl = "mf-url.dev";
+        var apiMock = new Mock<IMultifactorApi>();
+        apiMock
+            .Setup(x => x.SendChallengeAsync(It.Is<string>(u => u == brokenUrl), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<Exception>();
+
+        apiMock
+            .Setup(x => x.SendChallengeAsync(It.Is<string>(u => u == mfUrl), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<Exception>();
+
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
+        contextMock.Setup(x => x.RequestPacket.CallingStationIdAttribute).Returns("CallingStationIdAttribute");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
+        contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
+
+        // Act
+        var response =
+            await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Reject, response.Code);
+        apiMock.Verify(
+            x => x.SendChallengeAsync(It.IsAny<string>(), It.IsAny<ChallengeRequest>(), It.IsAny<ApiCredential>()),
+            Times.Exactly(2));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SendChallenge_MultipleUrlsFirstResponse_ShouldAccept(bool bypass)
+    {
+        // Arrange
+        var brokenUrl = "broken-url.com";
+        var mfUrl = "mf-url.dev";
+        var apiMock = new Mock<IMultifactorApi>();
+
+        apiMock
+            .Setup(x => x.SendChallengeAsync(It.Is<string>(u => u == brokenUrl), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .Throws<MultifactorApiUnreachableException>();
+
+        apiMock
+            .Setup(x => x.SendChallengeAsync(It.Is<string>(u => u == mfUrl), It.IsAny<ChallengeRequest>(),
+                It.IsAny<ApiCredential>()))
+            .ReturnsAsync(() => new AccessRequestResponse()
+            {
+                Status = RequestStatus.Granted
+            });
+
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket.CalledStationIdAttribute).Returns("CalledStationIdAttribute");
+        contextMock.Setup(x => x.RequestPacket.CallingStationIdAttribute).Returns("CallingStationIdAttribute");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime)
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(bypass);
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
+        contextMock.Setup(x => x.ApiUrls).Returns([mfUrl, brokenUrl]);
+
+        // Act
+        var response =
+            await service.SendChallengeAsync(new SendChallengeRequest(contextMock.Object, "answer", "requestId"));
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Accept, response.Code);
+        apiMock.Verify(
+            x => x.SendChallengeAsync(It.IsAny<string>(), It.IsAny<ChallengeRequest>(), It.IsAny<ApiCredential>()),
+            Times.Exactly(1));
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/MultifactorApi/MultifactorApiTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/MultifactorApi/MultifactorApiTests.cs
@@ -14,7 +14,7 @@ public class MultifactorApiTests
     {
         var clientMock = new Mock<IHttpClient>();
         var api = new Services.MultifactorApi.MultifactorApi(clientMock.Object, NullLogger<Services.MultifactorApi.MultifactorApi>.Instance);
-        await Assert.ThrowsAsync<ArgumentNullException>(() => api.CreateAccessRequest(null, new ApiCredential("key", "secret")));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => api.CreateAccessRequest("url", null, new ApiCredential("key", "secret")));
     }
     
     [Fact]
@@ -22,7 +22,7 @@ public class MultifactorApiTests
     {
         var clientMock = new Mock<IHttpClient>();
         var api = new Services.MultifactorApi.MultifactorApi(clientMock.Object, NullLogger<Services.MultifactorApi.MultifactorApi>.Instance);
-        await Assert.ThrowsAsync<ArgumentNullException>(() => api.CreateAccessRequest(new AccessRequest(), null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => api.CreateAccessRequest("url", new AccessRequest(), null));
     }
     
     [Fact]
@@ -35,7 +35,7 @@ public class MultifactorApiTests
             .ReturnsAsync(() => null);
         
         var api = new Services.MultifactorApi.MultifactorApi(clientMock.Object, NullLogger<Services.MultifactorApi.MultifactorApi>.Instance);
-        var response = await api.CreateAccessRequest(new AccessRequest(), new ApiCredential("key", "secret"));
+        var response = await api.CreateAccessRequest("url", new AccessRequest(), new ApiCredential("key", "secret"));
         Assert.NotNull(response);
         Assert.Equal(RequestStatus.Denied, response.Status);
     }
@@ -52,7 +52,7 @@ public class MultifactorApiTests
             .ReturnsAsync(() => new MultiFactorApiResponse<AccessRequestResponse>() { Success = success, Model = new AccessRequestResponse() {Status = RequestStatus.Granted} } );
         
         var api = new Services.MultifactorApi.MultifactorApi(clientMock.Object, NullLogger<Services.MultifactorApi.MultifactorApi>.Instance);
-        var response = await api.CreateAccessRequest(new AccessRequest(), new ApiCredential("key", "secret"));
+        var response = await api.CreateAccessRequest("url", new AccessRequest(), new ApiCredential("key", "secret"));
         Assert.NotNull(response);
         Assert.Equal(RequestStatus.Granted, response.Status);
     }
@@ -68,7 +68,7 @@ public class MultifactorApiTests
             .Throws(new HttpRequestException());
         
         var api = new Services.MultifactorApi.MultifactorApi(clientMock.Object, NullLogger<Services.MultifactorApi.MultifactorApi>.Instance);
-        await Assert.ThrowsAsync<MultifactorApiUnreachableException>(() => api.CreateAccessRequest(new AccessRequest(), new ApiCredential("key", "secret")));
+        await Assert.ThrowsAsync<MultifactorApiUnreachableException>(() => api.CreateAccessRequest("url", new AccessRequest(), new ApiCredential("key", "secret")));
     }
     
     [Fact]
@@ -81,7 +81,7 @@ public class MultifactorApiTests
             .Throws(new HttpRequestException(string.Empty, null, HttpStatusCode.TooManyRequests));
         
         var api = new Services.MultifactorApi.MultifactorApi(clientMock.Object, NullLogger<Services.MultifactorApi.MultifactorApi>.Instance);
-        var response = await api.CreateAccessRequest(new AccessRequest(), new ApiCredential("key", "secret"));
+        var response = await api.CreateAccessRequest("url", new AccessRequest(), new ApiCredential("key", "secret"));
         Assert.NotNull(response);
         Assert.Equal(RequestStatus.Denied, response.Status);
     }
@@ -96,7 +96,7 @@ public class MultifactorApiTests
             .Throws(new TaskCanceledException());
         
         var api = new Services.MultifactorApi.MultifactorApi(clientMock.Object, NullLogger<Services.MultifactorApi.MultifactorApi>.Instance);
-        await Assert.ThrowsAsync<MultifactorApiUnreachableException>(() => api.CreateAccessRequest(new AccessRequest(), new ApiCredential("key", "secret")));
+        await Assert.ThrowsAsync<MultifactorApiUnreachableException>(() => api.CreateAccessRequest("url", new AccessRequest(), new ApiCredential("key", "secret")));
     }
     
     [Fact]
@@ -109,6 +109,6 @@ public class MultifactorApiTests
             .Throws(new Exception());
         
         var api = new Services.MultifactorApi.MultifactorApi(clientMock.Object, NullLogger<Services.MultifactorApi.MultifactorApi>.Instance);
-        await Assert.ThrowsAsync<MultifactorApiUnreachableException>(() => api.CreateAccessRequest(new AccessRequest(), new ApiCredential("key", "secret")));
+        await Assert.ThrowsAsync<MultifactorApiUnreachableException>(() => api.CreateAccessRequest("url", new AccessRequest(), new ApiCredential("key", "secret")));
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Client/Build/ClientConfigurationFactory.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Client/Build/ClientConfigurationFactory.cs
@@ -44,13 +44,16 @@ public class ClientConfigurationFactory : IClientConfigurationFactory
         var firstFactorAuthenticationSource = Enum.Parse<AuthenticationSource>(
             appSettings.FirstFactorAuthenticationSource,
             true);
-
+        
+        var appSettingsUrls = Utils.SplitString(appSettings.MultifactorApiUrl);
+        var mfUrls = serviceConfig.ApiUrls.Count > 0 ? serviceConfig.ApiUrls : appSettingsUrls;
         var builder = new ClientConfiguration(
             name,
             appSettings.RadiusSharedSecret,
             firstFactorAuthenticationSource,
             appSettings.MultifactorNasIdentifier,
-            appSettings.MultifactorSharedSecret);
+            appSettings.MultifactorSharedSecret,
+            mfUrls);
 
         builder.SetBypassSecondFactorWhenApiUnreachable(appSettings.BypassSecondFactorWhenApiUnreachable);
 

--- a/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Client/ClientConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Client/ClientConfiguration.cs
@@ -12,12 +12,14 @@ public class ClientConfiguration : IClientConfiguration
     private readonly List<ILdapServerConfiguration> _ldapServers = new();
 
     public IReadOnlyList<ILdapServerConfiguration> LdapServers => _ldapServers;
+    public IReadOnlyList<string> ApiUrls { get; }
 
     public ClientConfiguration(string name,
         string rdsSharedSecret,
         AuthenticationSource firstFactorAuthSource,
         string apiKey,
-        string apiSecret)
+        string apiSecret,
+        IEnumerable<string> apiUrls)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException($"'{nameof(name)}' cannot be null or whitespace.", nameof(name));
@@ -31,6 +33,10 @@ public class ClientConfiguration : IClientConfiguration
 
         if (string.IsNullOrWhiteSpace(apiSecret))
             throw new ArgumentException($"'{nameof(apiSecret)}' cannot be null or whitespace.", nameof(apiSecret));
+        
+        var urls = apiUrls?.ToList();
+        if (urls is null || urls.Count == 0)
+            throw new ArgumentException($"'{nameof(apiUrls)}' cannot be null or empty.", nameof(apiUrls));
 
         BypassSecondFactorWhenApiUnreachable = true; //by default
 
@@ -38,6 +44,7 @@ public class ClientConfiguration : IClientConfiguration
         RadiusSharedSecret = rdsSharedSecret;
         FirstFactorAuthenticationSource = firstFactorAuthSource;
         ApiCredential = new ApiCredential(apiKey, apiSecret);
+        ApiUrls = urls;
     }
 
     /// <summary>

--- a/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Client/IClientConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Client/IClientConfiguration.cs
@@ -25,4 +25,5 @@ public interface IClientConfiguration
     UserNameTransformRules UserNameTransformRules { get; }
     RandomWaiterConfig InvalidCredentialDelay { get; }
     PreAuthModeDescriptor PreAuthnMode { get; }
+    IReadOnlyList<string> ApiUrls { get; }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Service/Build/ServiceConfigurationFactory.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Service/Build/ServiceConfigurationFactory.cs
@@ -39,18 +39,9 @@ public class ServiceConfigurationFactory : IServiceConfigurationFactory
         }
 
         var appSettings = rootConfiguration.AppSettings;
-
-        var apiUrlSetting = appSettings.MultifactorApiUrl;
+        
         var apiProxySetting = appSettings.MultifactorApiProxy;
         var apiTimeoutSetting = appSettings.MultifactorApiTimeout;
-        
-        if (string.IsNullOrWhiteSpace(apiUrlSetting))
-        {
-            throw InvalidConfigurationException.For(
-                x => x.AppSettings.MultifactorApiUrl,
-                "'{prop}' element not found. Config name: '{0}'",
-                RadiusAdapterConfigurationFile.ConfigName);
-        }
 
         IPEndPoint serviceServerEndpoint = ParseAdapterServerEndpoint(appSettings);
         
@@ -79,13 +70,12 @@ public class ServiceConfigurationFactory : IServiceConfigurationFactory
         
         var builder = new ServiceConfiguration()
             .SetServiceServerEndpoint(serviceServerEndpoint)
-            .SetApiUrl(apiUrlSetting)
             .SetApiTimeout(apiTimeout);
-
+        
+        ReadMultifactorApiUrlSetting(appSettings, builder);
+        
         if (!string.IsNullOrWhiteSpace(apiProxySetting))
-        {
             builder.SetApiProxy(apiProxySetting);
-        }
 
         ReadInvalidCredDelaySetting(appSettings, builder);
 
@@ -98,9 +88,7 @@ public class ServiceConfigurationFactory : IServiceConfigurationFactory
         }
 
         foreach (var clientConfig in clientConfigs)
-        {
             AddClient(clientConfig, builder);
-        }
 
         return builder;
     }
@@ -193,5 +181,21 @@ public class ServiceConfigurationFactory : IServiceConfigurationFactory
                 "Can't parse '{prop}' value. Config name: '{0}'",
                 RadiusAdapterConfigurationFile.ConfigName);            
         }
+    }
+
+    private static void ReadMultifactorApiUrlSetting(AppSettingsSection appSettings, ServiceConfiguration builder)
+    {
+        var apiUrlSetting = appSettings.MultifactorApiUrl;
+        if (string.IsNullOrWhiteSpace(apiUrlSetting))
+        {
+            throw InvalidConfigurationException.For(
+                x => x.AppSettings.MultifactorApiUrl,
+                "'{prop}' element not found. Config name: '{0}'",
+                RadiusAdapterConfigurationFile.ConfigName);
+        }
+
+        var urls = Utils.SplitString(apiUrlSetting);
+        foreach (var url in urls)
+            builder.AddApiUrl(url);
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Service/IServiceConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Service/IServiceConfiguration.cs
@@ -8,7 +8,7 @@ namespace Multifactor.Radius.Adapter.v2.Core.Configuration.Service;
 public interface IServiceConfiguration
 {
     string ApiProxy { get; }
-    string ApiUrl { get; }
+    IReadOnlyList<string> ApiUrls { get; }
     TimeSpan ApiTimeout { get; }
     ReadOnlyCollection<IClientConfiguration> Clients { get; }
     RandomWaiterConfig InvalidCredentialDelay { get; }

--- a/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Service/ServiceConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Service/ServiceConfiguration.cs
@@ -8,6 +8,7 @@ namespace Multifactor.Radius.Adapter.v2.Core.Configuration.Service;
 
 public class ServiceConfiguration : IServiceConfiguration
 {
+    private readonly List<string> _apiUrls = new();
     /// <summary>
     /// List of clients with identification by client ip
     /// </summary>
@@ -52,9 +53,9 @@ public class ServiceConfiguration : IServiceConfiguration
     public IPEndPoint ServiceServerEndpoint { get; private set; }
 
     /// <summary>
-    /// Multifactor API URL
+    /// Multifactor API URLs
     /// </summary>
-    public string ApiUrl { get; private set; }
+    public IReadOnlyList<string> ApiUrls => _apiUrls;
 
     /// <summary>
     /// HTTP Proxy for API
@@ -78,12 +79,12 @@ public class ServiceConfiguration : IServiceConfiguration
         return this;
     }
 
-    public ServiceConfiguration SetApiUrl(string val)
+    public ServiceConfiguration AddApiUrl(string val)
     {
         if (string.IsNullOrWhiteSpace(val))
             throw new ArgumentException($"'{nameof(val)}' cannot be null or whitespace.", nameof(val));
 
-        ApiUrl = val;
+        _apiUrls.Add(val);
         return this;
     }
 

--- a/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Service/ServiceConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Service/ServiceConfiguration.cs
@@ -83,8 +83,10 @@ public class ServiceConfiguration : IServiceConfiguration
     {
         if (string.IsNullOrWhiteSpace(val))
             throw new ArgumentException($"'{nameof(val)}' cannot be null or whitespace.", nameof(val));
-
-        _apiUrls.Add(val);
+        
+        if (!_apiUrls.Contains(val))
+            _apiUrls.Add(val);
+        
         return this;
     }
 

--- a/src/Multifactor.Radius.Adapter.v2/Core/Pipeline/Settings/IPipelineExecutionSettings.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Pipeline/Settings/IPipelineExecutionSettings.cs
@@ -26,4 +26,5 @@ public interface IPipelineExecutionSettings
     PreAuthModeDescriptor PreAuthnMode { get; }
     string ClientConfigurationName { get; }
     SharedSecret RadiusSharedSecret { get; }
+    IReadOnlyList<string> ApiUrls { get; }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Core/Pipeline/Settings/PipelineExecutionSettings.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Pipeline/Settings/PipelineExecutionSettings.cs
@@ -28,6 +28,7 @@ public class PipelineExecutionSettings : IPipelineExecutionSettings
     public RandomWaiterConfig InvalidCredentialDelay => _configuration.InvalidCredentialDelay;
     public PreAuthModeDescriptor PreAuthnMode => _configuration.PreAuthnMode;
     public SharedSecret RadiusSharedSecret => _sharedSecret;
+    public IReadOnlyList<string> ApiUrls => _configuration.ApiUrls;
     public string ClientConfigurationName => _configuration.Name;
     
     public PipelineExecutionSettings(IClientConfiguration clientConfiguration, ILdapServerConfiguration? ldapServerConfiguration = null)

--- a/src/Multifactor.Radius.Adapter.v2/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Http.Resilience;
 using Multifactor.Core.Ldap.Connection.LdapConnectionFactory;
 using Multifactor.Core.Ldap.LdapGroup.Load;
 using Multifactor.Core.Ldap.LdapGroup.Membership;
@@ -27,6 +28,7 @@ using Multifactor.Radius.Adapter.v2.Services.LdapForest;
 using Multifactor.Radius.Adapter.v2.Services.MultifactorApi;
 using Multifactor.Radius.Adapter.v2.Services.NetBios;
 using Multifactor.Radius.Adapter.v2.Services.Radius;
+using Polly;
 using Serilog;
 using ILdapConnectionFactory = Multifactor.Radius.Adapter.v2.Core.Ldap.ILdapConnectionFactory;
 
@@ -108,28 +110,38 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<IHttpClient, MultifactorHttpClient>();
         services.AddHttpClient(nameof(MultifactorHttpClient), (prov, client) =>
-        {
-            var config = prov.GetRequiredService<IServiceConfiguration>();
-            client.Timeout = config.ApiTimeout;
-        }).ConfigurePrimaryHttpMessageHandler(prov =>
-        {
-            var config = prov.GetRequiredService<IServiceConfiguration>();
-            var handler = new HttpClientHandler
             {
-                MaxConnectionsPerServer = 100,
-                SslProtocols = SslProtocols.Tls13 | SslProtocols.Tls12
-            };
-            
-            if (string.IsNullOrWhiteSpace(config.ApiProxy))
+                var config = prov.GetRequiredService<IServiceConfiguration>();
+                client.Timeout = config.ApiTimeout;
+            }).ConfigurePrimaryHttpMessageHandler(prov =>
+            {
+                var config = prov.GetRequiredService<IServiceConfiguration>();
+                var handler = new HttpClientHandler
+                {
+                    MaxConnectionsPerServer = 100,
+                    SslProtocols = SslProtocols.Tls13 | SslProtocols.Tls12
+                };
+
+                if (string.IsNullOrWhiteSpace(config.ApiProxy))
+                    return handler;
+
+                if (!WebProxyFactory.TryCreateWebProxy(config.ApiProxy, out var webProxy))
+                    throw new Exception(
+                        "Unable to initialize WebProxy. Please, check whether multifactor-api-proxy URI is valid.");
+
+                handler.Proxy = webProxy;
+
                 return handler;
-            
-            if (!WebProxyFactory.TryCreateWebProxy(config.ApiProxy, out var webProxy))
-                throw new Exception("Unable to initialize WebProxy. Please, check whether multifactor-api-proxy URI is valid.");
-
-            handler.Proxy = webProxy;
-
-            return handler;
-        });
+            })
+            .AddResilienceHandler("mf-api-pipeline", x =>
+            {
+                x.AddRetry(new HttpRetryStrategyOptions
+                {
+                    MaxRetryAttempts = 2,
+                    Delay = TimeSpan.FromSeconds(1),
+                    BackoffType = DelayBackoffType.Exponential
+                });
+            });
     }
 
     public static void AddRadiusDictionary(this IServiceCollection services)
@@ -190,16 +202,16 @@ public static class ServiceCollectionExtensions
     public static void AddServices(this IServiceCollection services)
     {
         services.AddTransient<IRadiusPacketService, RadiusPacketService>();
-        
+
         services.AddSingleton<IAuthenticatedClientCache, AuthenticatedClientCache>();
-        
+
         services.AddSingleton(LdapConnectionFactory.Create());
         services.AddSingleton<ILdapConnectionFactory, CustomLdapConnectionFactory>((prov) => new CustomLdapConnectionFactory());
-        
+
         services.AddSingleton<ILdapGroupLoaderFactory, LdapGroupLoaderFactory>();
         services.AddSingleton<IMembershipCheckerFactory, MembershipCheckerFactory>();
         services.AddTransient<ILdapGroupService, LdapGroupService>();
-        
+
         services.AddSingleton<IForestMetadataCache, ForestMetadataCache>();
         services.AddTransient<ILdapProfileService, LdapProfileService>();
 

--- a/src/Multifactor.Radius.Adapter.v2/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Extensions/ServiceCollectionExtensions.cs
@@ -110,7 +110,6 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient(nameof(MultifactorHttpClient), (prov, client) =>
         {
             var config = prov.GetRequiredService<IServiceConfiguration>();
-            client.BaseAddress = new Uri(config.ApiUrl);
             client.Timeout = config.ApiTimeout;
         }).ConfigurePrimaryHttpMessageHandler(prov =>
         {

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Context/IRadiusPipelineExecutionContext.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Context/IRadiusPipelineExecutionContext.cs
@@ -43,4 +43,5 @@ public interface IRadiusPipelineExecutionContext
     PreAuthModeDescriptor PreAuthnMode { get; }
     string ClientConfigurationName { get; }
     SharedSecret RadiusSharedSecret { get; }
+    IReadOnlyList<string> ApiUrls { get; }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Context/RadiusPipelineExecutionContext.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Context/RadiusPipelineExecutionContext.cs
@@ -46,6 +46,7 @@ public class RadiusPipelineExecutionContext : IRadiusPipelineExecutionContext
     public PreAuthModeDescriptor PreAuthnMode => _settings.PreAuthnMode;
     public string ClientConfigurationName => _settings.ClientConfigurationName;
     public SharedSecret RadiusSharedSecret => _settings.RadiusSharedSecret;
+    public IReadOnlyList<string> ApiUrls => _settings.ApiUrls;
 
     public RadiusPipelineExecutionContext(IPipelineExecutionSettings settings, IRadiusPacket requestPacket)
     {

--- a/src/Multifactor.Radius.Adapter.v2/Multifactor.Radius.Adapter.v2.csproj
+++ b/src/Multifactor.Radius.Adapter.v2/Multifactor.Radius.Adapter.v2.csproj
@@ -39,6 +39,7 @@
         <PackageReference Include="System.Text.Json" Version="9.0.1" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/CreateSecondFactorRequest.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/CreateSecondFactorRequest.cs
@@ -27,6 +27,7 @@ public class CreateSecondFactorRequest
     public string? IdentityAttribute { get; }
     public bool BypassSecondFactorWhenApiUnreachable { get; }
     public IReadOnlyList<string> PhoneAttributesNames { get; }
+    public IReadOnlyList<string> ApiUrls { get; }
 
     public CreateSecondFactorRequest(IRadiusPipelineExecutionContext context)
     {
@@ -56,5 +57,6 @@ public class CreateSecondFactorRequest
         IdentityAttribute = context.LdapServerConfiguration?.IdentityAttribute;
         BypassSecondFactorWhenApiUnreachable = context.BypassSecondFactorWhenApiUnreachable;
         PhoneAttributesNames = context.LdapServerConfiguration?.PhoneAttributes ?? new List<string>();
+        ApiUrls = context.ApiUrls;
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/IMultifactorApi.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/IMultifactorApi.cs
@@ -4,6 +4,6 @@ namespace Multifactor.Radius.Adapter.v2.Services.MultifactorApi;
 
 public interface IMultifactorApi
 {
-    Task<AccessRequestResponse> CreateAccessRequest(AccessRequest payload, ApiCredential apiCredentials);
-    Task<AccessRequestResponse> SendChallengeAsync(ChallengeRequest payload, ApiCredential apiCredentials);
+    Task<AccessRequestResponse> CreateAccessRequest(string address, AccessRequest payload, ApiCredential apiCredentials);
+    Task<AccessRequestResponse> SendChallengeAsync(string address, ChallengeRequest payload, ApiCredential apiCredentials);
 }

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApi.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApi.cs
@@ -26,6 +26,7 @@ public class MultifactorApi : IMultifactorApi
         ArgumentNullException.ThrowIfNull(payload, nameof(payload));
         ArgumentNullException.ThrowIfNull(apiCredentials, nameof(apiCredentials));
         ArgumentException.ThrowIfNullOrWhiteSpace(address);
+        
         return SendRequestAsync($"{address}/access/requests/ra", payload, apiCredentials);
     }
 
@@ -34,6 +35,7 @@ public class MultifactorApi : IMultifactorApi
         ArgumentNullException.ThrowIfNull(payload, nameof(payload));
         ArgumentNullException.ThrowIfNull(apiCredentials, nameof(apiCredentials));
         ArgumentException.ThrowIfNullOrWhiteSpace(address);
+        
         return SendRequestAsync($"{address}/access/requests/ra/challenge", payload, apiCredentials);
     }
 

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApi.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApi.cs
@@ -21,20 +21,20 @@ public class MultifactorApi : IMultifactorApi
         _httpClient = httpClient;
     }
 
-    public Task<AccessRequestResponse> CreateAccessRequest(AccessRequest payload, ApiCredential apiCredentials)
+    public Task<AccessRequestResponse> CreateAccessRequest(string address, AccessRequest payload, ApiCredential apiCredentials)
     {
         ArgumentNullException.ThrowIfNull(payload, nameof(payload));
         ArgumentNullException.ThrowIfNull(apiCredentials, nameof(apiCredentials));
-
-        return SendRequestAsync("access/requests/ra", payload, apiCredentials);
+        ArgumentException.ThrowIfNullOrWhiteSpace(address);
+        return SendRequestAsync($"{address}/access/requests/ra", payload, apiCredentials);
     }
 
-    public Task<AccessRequestResponse> SendChallengeAsync(ChallengeRequest payload, ApiCredential apiCredentials)
+    public Task<AccessRequestResponse> SendChallengeAsync(string address, ChallengeRequest payload, ApiCredential apiCredentials)
     {
         ArgumentNullException.ThrowIfNull(payload, nameof(payload));
         ArgumentNullException.ThrowIfNull(apiCredentials, nameof(apiCredentials));
-
-        return SendRequestAsync("access/requests/ra/challenge", payload, apiCredentials);
+        ArgumentException.ThrowIfNullOrWhiteSpace(address);
+        return SendRequestAsync($"{address}/access/requests/ra/challenge", payload, apiCredentials);
     }
 
     private async Task<AccessRequestResponse> SendRequestAsync(string url, object payload, ApiCredential credentials)

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApiService.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApiService.cs
@@ -57,26 +57,53 @@ public class MultifactorApiService : IMultifactorApiService
         ApplyPrivacyMode(personalData, request.PrivacyMode);
         var payload = GetRequestPayload(personalData, request);
 
-        try
+        MultifactorResponse cloudResponse = new MultifactorResponse(AuthenticationStatus.Reject);
+        foreach (var apiUrl in request.ApiUrls)
         {
-            var response = await CreateAccessRequestAsync(personalData, payload, request);
-            var responseCode = ConvertToAuthCode(response);
-            if (responseCode == AuthenticationStatus.Accept && !(response?.Bypassed ?? false))
+            // TODO move to method
+            try
             {
-                LogGrantedInfo(personalData.Identity, response, request.RequestPacket.CallingStationIdAttribute);
-                _authenticatedClientCache.SetCache(callingStationId, personalData.Identity, request.ConfigName, request.AuthenticationCacheLifetime);
-            }
+                var response = await CreateAccessRequestAsync(apiUrl, payload, request.ApiCredential);
+                var responseCode = ConvertToAuthCode(response);
 
-            return new MultifactorResponse(responseCode, response?.Id, response?.ReplyMessage);
+                if (responseCode == AuthenticationStatus.Reject)
+                {
+                    var reason = response?.ReplyMessage;
+                    var phone = response?.Phone;
+                    _logger.LogWarning(
+                        "Second factor verification for user '{user:l}' from {host:l}:{port} failed with reason='{reason:l}'. User phone {phone:l}",
+                        personalData.Identity,
+                        request.RemoteEndpoint.Address,
+                        request.RemoteEndpoint.Port,
+                        reason,
+                        phone);
+                }
+
+                if (responseCode == AuthenticationStatus.Accept && !(response?.Bypassed ?? false))
+                {
+                    LogGrantedInfo(personalData.Identity, response, request.RequestPacket.CallingStationIdAttribute);
+                    _authenticatedClientCache.SetCache(callingStationId, personalData.Identity, request.ConfigName,
+                        request.AuthenticationCacheLifetime);
+                }
+
+                return new MultifactorResponse(responseCode, response?.Id, response?.ReplyMessage);
+            }
+            catch (MultifactorApiUnreachableException apiEx)
+            {
+                cloudResponse = ProcessMfException(apiEx, personalData.Identity,
+                    request.BypassSecondFactorWhenApiUnreachable, request.RemoteEndpoint);
+            }
+            catch (Exception ex)
+            {
+                cloudResponse = ProcessException(ex, personalData.Identity, request.RemoteEndpoint);
+            }
         }
-        catch (MultifactorApiUnreachableException apiEx)
-        {
-            return ProcessMfException(apiEx, personalData.Identity, request.BypassSecondFactorWhenApiUnreachable, request.RemoteEndpoint);
-        }
-        catch (Exception ex)
-        {
-            return ProcessException(ex, personalData.Identity, request.RemoteEndpoint);
-        }
+
+        if (cloudResponse.Code == AuthenticationStatus.Bypass)
+            _logger.LogWarning("Bypass second factor for user '{user:l}' from {host:l}:{port}", personalData.Identity,
+                request.RemoteEndpoint.Address, request.RemoteEndpoint.Port);
+
+        return cloudResponse;
     }
 
     public async Task<MultifactorResponse> SendChallengeAsync(SendChallengeRequest request)
@@ -85,7 +112,8 @@ public class MultifactorApiService : IMultifactorApiService
         ArgumentException.ThrowIfNullOrWhiteSpace(request.RequestId, nameof(request.RequestId));
         ArgumentException.ThrowIfNullOrWhiteSpace(request.Answer, nameof(request.Answer));
 
-        var identity = GetSecondFactorIdentity(request.IdentityAttribute, request.RequestPacket.UserName, request.UserProfile?.Attributes ?? []);
+        var identity = GetSecondFactorIdentity(request.IdentityAttribute, request.RequestPacket.UserName,
+            request.UserProfile?.Attributes ?? []);
         if (string.IsNullOrWhiteSpace(identity))
             throw new InvalidOperationException("The identity is empty.");
 
@@ -96,26 +124,66 @@ public class MultifactorApiService : IMultifactorApiService
             RequestId = request.RequestId
         };
 
-        try
+        MultifactorResponse cloudResponse = new MultifactorResponse(AuthenticationStatus.Reject);
+        foreach (var apiUrl in request.ApiUrls)
         {
-            var response = await _api.SendChallengeAsync(payload, request.ApiCredential);
-            var responseCode = ConvertToAuthCode(response);
-            if (responseCode != AuthenticationStatus.Accept || response.Bypassed)
-                return new MultifactorResponse(responseCode, response?.ReplyMessage);
-            LogGrantedInfo(identity, response, request.RequestPacket.CallingStationIdAttribute);
-            _authenticatedClientCache.SetCache(request.RequestPacket.CallingStationIdAttribute, identity, request.ConfigName, request.AuthenticationCacheLifetime);
+            // TODO move to method
+            try
+            {
+                var response = await _api.SendChallengeAsync(apiUrl, payload, request.ApiCredential);
+                var responseCode = ConvertToAuthCode(response);
+                if (responseCode != AuthenticationStatus.Accept || response.Bypassed)
+                    return new MultifactorResponse(responseCode, response?.ReplyMessage);
+                LogGrantedInfo(identity, response, request.RequestPacket.CallingStationIdAttribute);
+                _authenticatedClientCache.SetCache(request.RequestPacket.CallingStationIdAttribute, identity,
+                    request.ConfigName, request.AuthenticationCacheLifetime);
 
-            return new MultifactorResponse(responseCode, response?.ReplyMessage);
+                return new MultifactorResponse(responseCode, response?.ReplyMessage);
+            }
+            catch (MultifactorApiUnreachableException apiEx)
+            {
+                cloudResponse = ProcessMfException(apiEx, identity, request.BypassSecondFactorWhenApiUnreachable,
+                    request.RemoteEndpoint);
+            }
+            catch (Exception ex)
+            {
+                cloudResponse = ProcessException(ex, identity, request.RemoteEndpoint);
+            }
         }
-        catch (MultifactorApiUnreachableException apiEx)
-        {
-            return ProcessMfException(apiEx, identity, request.BypassSecondFactorWhenApiUnreachable, request.RemoteEndpoint);
-        }
-        catch (Exception ex)
-        {
-            return ProcessException(ex, identity, request.RemoteEndpoint);
-        }
+
+        if (cloudResponse.Code == AuthenticationStatus.Bypass)
+            _logger.LogWarning("Bypass second factor for user '{user:l}' from {host:l}:{port}", identity,
+                request.RemoteEndpoint.Address, request.RemoteEndpoint.Port);
+
+        return cloudResponse;
     }
+
+    /*private async Task<MultifactorResponse> ProcessMultifactorApiUrl(string apiUrl, AccessRequest payload, CreateSecondFactorRequest request, PersonalData personalData, string? callingStationId)
+    {
+        var response = await CreateAccessRequestAsync(apiUrl, payload, request.ApiCredential);
+        var responseCode = ConvertToAuthCode(response);
+
+        if (responseCode == AuthenticationStatus.Reject)
+        {
+            var reason = response?.ReplyMessage;
+            var phone = response?.Phone;
+            _logger.LogWarning(
+                "Second factor verification for user '{user:l}' from {host:l}:{port} failed with reason='{reason:l}'. User phone {phone:l}",
+                personalData.Identity,
+                request.RemoteEndpoint.Address,
+                request.RemoteEndpoint.Port,
+                reason,
+                phone);
+        }
+
+        if (responseCode == AuthenticationStatus.Accept && !(response?.Bypassed ?? false))
+        {
+            LogGrantedInfo(personalData.Identity, response, request.RequestPacket.CallingStationIdAttribute);
+            _authenticatedClientCache.SetCache(callingStationId, personalData.Identity, request.ConfigName, request.AuthenticationCacheLifetime);
+        }
+
+        return new MultifactorResponse(responseCode, response?.Id, response?.ReplyMessage);
+    }*/
 
     private AuthenticationStatus ConvertToAuthCode(AccessRequestResponse? multifactorAccessRequest)
     {
@@ -201,24 +269,10 @@ public class MultifactorApiService : IMultifactorApiService
         return passphrase.Otp ?? passphrase.ProviderCode;
     }
 
-    private async Task<AccessRequestResponse?> CreateAccessRequestAsync(PersonalData personalData, AccessRequest payload, CreateSecondFactorRequest context)
+    private async Task<AccessRequestResponse?> CreateAccessRequestAsync(string address, AccessRequest payload,
+        ApiCredential apiCredential)
     {
-        var response = await _api.CreateAccessRequest(payload, context.ApiCredential);
-        var responseCode = ConvertToAuthCode(response);
-
-        if (responseCode == AuthenticationStatus.Reject)
-        {
-            var reason = response?.ReplyMessage;
-            var phone = response?.Phone;
-            _logger.LogWarning(
-                "Second factor verification for user '{user:l}' from {host:l}:{port} failed with reason='{reason:l}'. User phone {phone:l}",
-                personalData.Identity,
-                context.RemoteEndpoint.Address,
-                context.RemoteEndpoint.Port,
-                reason,
-                phone);
-        }
-
+        var response = await _api.CreateAccessRequest(address, payload, apiCredential);
         return response;
     }
 
@@ -231,8 +285,9 @@ public class MultifactorApiService : IMultifactorApiService
             .FirstOrDefault(x => x.Name == context.IdentityAttribute)?.Values
             .FirstOrDefault();
     }
-    
-    private string? GetSecondFactorIdentity(string? identityAttribute, string? userName, IReadOnlyCollection<LdapAttribute> profileAttributes)
+
+    private string? GetSecondFactorIdentity(string? identityAttribute, string? userName,
+        IReadOnlyCollection<LdapAttribute> profileAttributes)
     {
         if (string.IsNullOrWhiteSpace(identityAttribute))
             return userName;
@@ -255,7 +310,7 @@ public class MultifactorApiService : IMultifactorApiService
             .Where(x => request.PhoneAttributesNames.Contains(x.Name.Value))
             .Select(x => x.GetNotEmptyValues().FirstOrDefault())
             .FirstOrDefault();
-        
+
         var personalData = new PersonalData
         {
             Identity = secondFactorIdentity!,
@@ -273,7 +328,8 @@ public class MultifactorApiService : IMultifactorApiService
     {
         return new AccessRequest
         {
-            Identity = UserNameTransformation.Transform(personalData.Identity, context.UserNameTransformRules.BeforeSecondFactor),
+            Identity = UserNameTransformation.Transform(personalData.Identity,
+                context.UserNameTransformRules.BeforeSecondFactor),
             Name = personalData.DisplayName,
             Email = personalData.Email,
             Phone = personalData.Phone,
@@ -322,8 +378,9 @@ public class MultifactorApiService : IMultifactorApiService
                 break;
         }
     }
-    
-    private MultifactorResponse ProcessMfException(MultifactorApiUnreachableException apiEx, string identity, bool bypassSecondFactorWhenApiUnreachable, IPEndPoint remoteEndpoint)
+
+    private MultifactorResponse ProcessMfException(MultifactorApiUnreachableException apiEx, string identity,
+        bool bypassSecondFactorWhenApiUnreachable, IPEndPoint remoteEndpoint)
     {
         _logger.LogError(apiEx,
             "Error occured while requesting API for user '{user:l}' from {host:l}:{port}, {msg:l}",
@@ -338,24 +395,19 @@ public class MultifactorApiService : IMultifactorApiService
             return new MultifactorResponse(radCode);
         }
 
-        _logger.LogWarning("Bypass second factor for user '{user:l}' from {host:l}:{port}",
-            identity,
-            remoteEndpoint.Address,
-            remoteEndpoint.Port);
-
         var code = ConvertToAuthCode(AccessRequestResponse.Bypass);
         return new MultifactorResponse(code);
     }
-    
+
     private MultifactorResponse ProcessException(Exception ex, string identity, IPEndPoint remoteEndpoint)
     {
-         _logger.LogError(ex, "Error occured while requesting API for user '{user:l}' from {host:l}:{port}, {msg:l}",
-             identity,
-             remoteEndpoint.Address,
-             remoteEndpoint.Port,
-             ex.Message);
+        _logger.LogError(ex, "Error occured while requesting API for user '{user:l}' from {host:l}:{port}, {msg:l}",
+            identity,
+            remoteEndpoint.Address,
+            remoteEndpoint.Port,
+            ex.Message);
 
-         var code = ConvertToAuthCode(null);
-         return new MultifactorResponse(code);
+        var code = ConvertToAuthCode(null);
+        return new MultifactorResponse(code);
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApiService.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApiService.cs
@@ -82,8 +82,7 @@ public class MultifactorApiService : IMultifactorApiService
                 if (responseCode == AuthenticationStatus.Accept && !(response?.Bypassed ?? false))
                 {
                     LogGrantedInfo(personalData.Identity, response, request.RequestPacket.CallingStationIdAttribute);
-                    _authenticatedClientCache.SetCache(callingStationId, personalData.Identity, request.ConfigName,
-                        request.AuthenticationCacheLifetime);
+                    _authenticatedClientCache.SetCache(callingStationId, personalData.Identity, request.ConfigName, request.AuthenticationCacheLifetime);
                 }
 
                 return new MultifactorResponse(responseCode, response?.Id, response?.ReplyMessage);
@@ -100,8 +99,7 @@ public class MultifactorApiService : IMultifactorApiService
         }
 
         if (cloudResponse.Code == AuthenticationStatus.Bypass)
-            _logger.LogWarning("Bypass second factor for user '{user:l}' from {host:l}:{port}", personalData.Identity,
-                request.RemoteEndpoint.Address, request.RemoteEndpoint.Port);
+            _logger.LogWarning("Bypass second factor for user '{user:l}' from {host:l}:{port}", personalData.Identity, request.RemoteEndpoint.Address, request.RemoteEndpoint.Port);
 
         return cloudResponse;
     }
@@ -112,8 +110,8 @@ public class MultifactorApiService : IMultifactorApiService
         ArgumentException.ThrowIfNullOrWhiteSpace(request.RequestId, nameof(request.RequestId));
         ArgumentException.ThrowIfNullOrWhiteSpace(request.Answer, nameof(request.Answer));
 
-        var identity = GetSecondFactorIdentity(request.IdentityAttribute, request.RequestPacket.UserName,
-            request.UserProfile?.Attributes ?? []);
+        var identity = GetSecondFactorIdentity(request.IdentityAttribute, request.RequestPacket.UserName, request.UserProfile?.Attributes ?? []);
+        
         if (string.IsNullOrWhiteSpace(identity))
             throw new InvalidOperationException("The identity is empty.");
 
@@ -132,18 +130,18 @@ public class MultifactorApiService : IMultifactorApiService
             {
                 var response = await _api.SendChallengeAsync(apiUrl, payload, request.ApiCredential);
                 var responseCode = ConvertToAuthCode(response);
+                
                 if (responseCode != AuthenticationStatus.Accept || response.Bypassed)
                     return new MultifactorResponse(responseCode, response?.ReplyMessage);
+                
                 LogGrantedInfo(identity, response, request.RequestPacket.CallingStationIdAttribute);
-                _authenticatedClientCache.SetCache(request.RequestPacket.CallingStationIdAttribute, identity,
-                    request.ConfigName, request.AuthenticationCacheLifetime);
+                _authenticatedClientCache.SetCache(request.RequestPacket.CallingStationIdAttribute, identity, request.ConfigName, request.AuthenticationCacheLifetime);
 
                 return new MultifactorResponse(responseCode, response?.ReplyMessage);
             }
             catch (MultifactorApiUnreachableException apiEx)
             {
-                cloudResponse = ProcessMfException(apiEx, identity, request.BypassSecondFactorWhenApiUnreachable,
-                    request.RemoteEndpoint);
+                cloudResponse = ProcessMfException(apiEx, identity, request.BypassSecondFactorWhenApiUnreachable, request.RemoteEndpoint);
             }
             catch (Exception ex)
             {
@@ -157,33 +155,6 @@ public class MultifactorApiService : IMultifactorApiService
 
         return cloudResponse;
     }
-
-    /*private async Task<MultifactorResponse> ProcessMultifactorApiUrl(string apiUrl, AccessRequest payload, CreateSecondFactorRequest request, PersonalData personalData, string? callingStationId)
-    {
-        var response = await CreateAccessRequestAsync(apiUrl, payload, request.ApiCredential);
-        var responseCode = ConvertToAuthCode(response);
-
-        if (responseCode == AuthenticationStatus.Reject)
-        {
-            var reason = response?.ReplyMessage;
-            var phone = response?.Phone;
-            _logger.LogWarning(
-                "Second factor verification for user '{user:l}' from {host:l}:{port} failed with reason='{reason:l}'. User phone {phone:l}",
-                personalData.Identity,
-                request.RemoteEndpoint.Address,
-                request.RemoteEndpoint.Port,
-                reason,
-                phone);
-        }
-
-        if (responseCode == AuthenticationStatus.Accept && !(response?.Bypassed ?? false))
-        {
-            LogGrantedInfo(personalData.Identity, response, request.RequestPacket.CallingStationIdAttribute);
-            _authenticatedClientCache.SetCache(callingStationId, personalData.Identity, request.ConfigName, request.AuthenticationCacheLifetime);
-        }
-
-        return new MultifactorResponse(responseCode, response?.Id, response?.ReplyMessage);
-    }*/
 
     private AuthenticationStatus ConvertToAuthCode(AccessRequestResponse? multifactorAccessRequest)
     {
@@ -269,8 +240,7 @@ public class MultifactorApiService : IMultifactorApiService
         return passphrase.Otp ?? passphrase.ProviderCode;
     }
 
-    private async Task<AccessRequestResponse?> CreateAccessRequestAsync(string address, AccessRequest payload,
-        ApiCredential apiCredential)
+    private async Task<AccessRequestResponse?> CreateAccessRequestAsync(string address, AccessRequest payload, ApiCredential apiCredential)
     {
         var response = await _api.CreateAccessRequest(address, payload, apiCredential);
         return response;
@@ -328,8 +298,7 @@ public class MultifactorApiService : IMultifactorApiService
     {
         return new AccessRequest
         {
-            Identity = UserNameTransformation.Transform(personalData.Identity,
-                context.UserNameTransformRules.BeforeSecondFactor),
+            Identity = UserNameTransformation.Transform(personalData.Identity, context.UserNameTransformRules.BeforeSecondFactor),
             Name = personalData.DisplayName,
             Email = personalData.Email,
             Phone = personalData.Phone,
@@ -379,8 +348,7 @@ public class MultifactorApiService : IMultifactorApiService
         }
     }
 
-    private MultifactorResponse ProcessMfException(MultifactorApiUnreachableException apiEx, string identity,
-        bool bypassSecondFactorWhenApiUnreachable, IPEndPoint remoteEndpoint)
+    private MultifactorResponse ProcessMfException(MultifactorApiUnreachableException apiEx, string identity, bool bypassSecondFactorWhenApiUnreachable, IPEndPoint remoteEndpoint)
     {
         _logger.LogError(apiEx,
             "Error occured while requesting API for user '{user:l}' from {host:l}:{port}, {msg:l}",

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/SendChallengeRequest.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/SendChallengeRequest.cs
@@ -19,6 +19,7 @@ public class SendChallengeRequest
     public IPEndPoint RemoteEndpoint { get;  }
     public string Answer { get; }
     public string RequestId { get; }
+    public IReadOnlyList<string> ApiUrls { get; }
 
     public SendChallengeRequest(IRadiusPipelineExecutionContext context, string answer, string requestId)
     {
@@ -41,5 +42,6 @@ public class SendChallengeRequest
         RemoteEndpoint = context.RemoteEndpoint;
         Answer = answer;
         RequestId = requestId;
+        ApiUrls = context.ApiUrls;
     }
 }


### PR DESCRIPTION
1. Обработка нескольких адресов MF облака происходит в `MultifactorApiService` в методах `CreateSecondFactorRequestAsync` и `SendChallengeAsync`. 
2. В `MultifactorApi` в методах `CreateAccessRequest` и `SendChallengeAsync` добавлен параметр `address`, отвечающий за адрес облака.
3. В метод `AddMultifactorHttpClient` добавлено использование `AddResilienceHandler`, как это было сделано для LDAP