### PR TITLE
DEV-903

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/FirstFactorAuth/LdapFirstFactorProcessorTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/FirstFactorAuth/LdapFirstFactorProcessorTests.cs
@@ -1,6 +1,9 @@
+using System.DirectoryServices.Protocols;
+using System.Net;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using Multifactor.Core.Ldap.Name;
+using Multifactor.Core.Ldap.Connection;
 using Multifactor.Core.Ldap.Schema;
 using Multifactor.Radius.Adapter.v2.Core;
 using Multifactor.Radius.Adapter.v2.Core.Auth;
@@ -12,120 +15,109 @@ using Multifactor.Radius.Adapter.v2.Core.Ldap;
 using Multifactor.Radius.Adapter.v2.Core.Radius.Packet;
 using Multifactor.Radius.Adapter.v2.Infrastructure.Pipeline.Context;
 using Multifactor.Radius.Adapter.v2.Tests.Fixture;
+using ILdapConnectionFactory = Multifactor.Core.Ldap.Connection.LdapConnectionFactory.ILdapConnectionFactory;
 
+namespace Multifactor.Radius.Adapter.v2.Tests.Unit.FirstFactorAuth;
 
-namespace Multifactor.Radius.Adapter.v2.Tests.FirstFactorAuthTests;
-
-[Collection("ActiveDirectory")]
 public class LdapFirstFactorProcessorTests
 {
     [Theory]
-    [InlineData("ActiveDirectoryCredentials.txt", "|", LdapImplementation.ActiveDirectory)]
-    [InlineData("FreeIpaCredentials.txt", "|", LdapImplementation.FreeIPA)]
-    public async Task LdapFirstFactorProcessor_CorrectCredentials_ShouldAccept(string config, string separator, LdapImplementation ldapImplementation)
+    [ClassData(typeof(EmptyStringsListInput))]
+    public async Task LdapFirstFactorProcessor_EmptyLogin_ShouldReject(string login)
     {
         //Arrange
-        var sensitiveData = GetConfig(config, separator);
-        var formatterProviderMock = new LdapBindNameFormatterProvider([new ActiveDirectoryFormatter(), new FreeIpaFormatter()]);
-
+        var formatterProviderMock = new LdapBindNameFormatterProvider([]);
         var processor = new LdapFirstFactorProcessor(new CustomLdapConnectionFactory(), formatterProviderMock, NullLogger<LdapFirstFactorProcessor>.Instance);
-
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         var packetMock = new Mock<IRadiusPacket>();
-        packetMock.Setup(x => x.UserName).Returns(sensitiveData["UserName"]);
-        packetMock.Setup(x => x.TryGetUserPassword()).Returns(sensitiveData["Password"]);
-        contextMock.Setup(x => x.RequestPacket).Returns(packetMock.Object);
-
-        var serverSettings = new Mock<ILdapServerConfiguration>();
-        serverSettings.Setup(x => x.ConnectionString).Returns(sensitiveData["ConnectionString"]);
-        serverSettings.Setup(x => x.BindTimeoutInSeconds).Returns(30);
-        contextMock.Setup(x => x.LdapServerConfiguration).Returns(serverSettings.Object);
-        
         var authState = new AuthenticationState();
-        contextMock.Setup(x => x.AuthenticationState).Returns(authState);
-
         var transformRules = new UserNameTransformRules();
+        packetMock.Setup(x => x.UserName).Returns(login);
+        packetMock.Setup(x => x.TryGetUserPassword()).Returns("correctLogin");
+        packetMock.Setup(x => x.Identifier).Returns(0);
+        contextMock.Setup(x => x.RequestPacket).Returns(packetMock.Object);
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.LdapServerConfiguration).Returns(new Mock<ILdapServerConfiguration>().Object);
+        contextMock.Setup(x => x.AuthenticationState).Returns(authState);
         contextMock.Setup(x => x.UserNameTransformRules).Returns(transformRules);
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
-        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse(sensitiveData["Password"], PreAuthModeDescriptor.Default));
-        contextMock.Setup(x => x.LdapSchema.LdapServerImplementation).Returns(ldapImplementation);
-        var profile = new Mock<ILdapProfile>();
-        profile.Setup(x => x.Dn).Returns(new DistinguishedName(sensitiveData["UserDn"]));
-        contextMock.Setup(x => x.UserLdapProfile).Returns(profile.Object);
+
+        //Act
+        await processor.ProcessFirstFactor(contextMock.Object);
+        
+        //Assert
+        Assert.Equal(AuthenticationStatus.Reject, authState.FirstFactorStatus);
+    }
+
+    [Theory]
+    [ClassData(typeof(EmptyStringsListInput))]
+    public async Task LdapFirstFactorProcessor_EmptyPassword_ShouldReject(string pwd)
+    {
+        //Arrange
+        var formatterProviderMock = new LdapBindNameFormatterProvider([]);
+        var processor = new LdapFirstFactorProcessor(new CustomLdapConnectionFactory(), formatterProviderMock, NullLogger<LdapFirstFactorProcessor>.Instance);
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        var packetMock = new Mock<IRadiusPacket>();
+        var authState = new AuthenticationState();
+        var transformRules = new UserNameTransformRules();
+        packetMock.Setup(x => x.UserName).Returns("correctLogin");
+        packetMock.Setup(x => x.TryGetUserPassword()).Returns(pwd);
+        packetMock.Setup(x => x.Identifier).Returns(0);
+        contextMock.Setup(x => x.RequestPacket).Returns(packetMock.Object);
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.LdapServerConfiguration).Returns(new Mock<ILdapServerConfiguration>().Object);
+        contextMock.Setup(x => x.AuthenticationState).Returns(authState);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(transformRules);
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         
         //Act
         await processor.ProcessFirstFactor(contextMock.Object);
         
         //Assert
-        Assert.Equal(AuthenticationStatus.Accept, authState.FirstFactorStatus);
+        Assert.Equal(AuthenticationStatus.Reject, authState.FirstFactorStatus);
     }
 
-    [Theory]
-    [InlineData("ActiveDirectoryCredentials.txt", "|")]
-    [InlineData("FreeIpaCredentials.txt", "|")]
-    public async Task LdapFirstFactorProcessor_IncorrectPassword_ShouldReject(string config, string separator)
+    [Fact]
+    public async Task LdapFirstFactorProcessor_MustChangePasswordResponse_ShouldReject()
     {
         //Arrange
-        var sensitiveData = GetConfig(config, separator);
-        var formatterProviderMock = new LdapBindNameFormatterProvider([]);
-        var processor = new LdapFirstFactorProcessor(new CustomLdapConnectionFactory(), formatterProviderMock, NullLogger<LdapFirstFactorProcessor>.Instance);
+        var factoryMock = new Mock<ILdapConnectionFactory>();
+        factoryMock.Setup(x => x.CreateConnection(It.IsAny<LdapConnectionOptions>())).Throws(GetLdapException);
+        factoryMock.Setup(x => x.TargetPlatform).Returns(OSPlatform.Windows);
+        var factory = new CustomLdapConnectionFactory([factoryMock.Object]);
+        var formatterProviderMock = new Mock<ILdapBindNameFormatterProvider>();
+        var processor = new LdapFirstFactorProcessor(factory, formatterProviderMock.Object, NullLogger<LdapFirstFactorProcessor>.Instance);
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         var packetMock = new Mock<IRadiusPacket>();
         var serverSettings = new Mock<ILdapServerConfiguration>();
         var authState = new AuthenticationState();
         var transformRules = new UserNameTransformRules();
-        packetMock.Setup(x => x.UserName).Returns(sensitiveData["UserName"]);
+        packetMock.Setup(x => x.UserName).Returns("user");
         packetMock.Setup(x => x.TryGetUserPassword()).Returns("pwd");
         contextMock.Setup(x => x.RequestPacket).Returns(packetMock.Object);
-        serverSettings.Setup(x => x.ConnectionString).Returns(sensitiveData["ConnectionString"]);
+        serverSettings.Setup(x => x.ConnectionString).Returns("your.domain");
         serverSettings.Setup(x => x.BindTimeoutInSeconds).Returns(30);
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(serverSettings.Object);
         contextMock.Setup(x => x.AuthenticationState).Returns(authState);
         contextMock.Setup(x => x.UserNameTransformRules).Returns(transformRules);
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.SetupProperty(x => x.MustChangePasswordDomain);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
-        
+        contextMock.Setup(x => x.LdapSchema.LdapServerImplementation).Returns(LdapImplementation.ActiveDirectory);
+        var context = contextMock.Object;
+
         //Act
-        await processor.ProcessFirstFactor(contextMock.Object);
+        await processor.ProcessFirstFactor(context);
         
         //Assert
         Assert.Equal(AuthenticationStatus.Reject, authState.FirstFactorStatus);
+        Assert.Equal("your.domain", context.MustChangePasswordDomain);
     }
 
-    [Theory]
-    [InlineData("ActiveDirectoryCredentials.txt", "|")]
-    [InlineData("FreeIpaCredentials.txt", "|")]
-    public async Task LdapFirstFactorProcessor_IncorrectLogin_ShouldReject(string config, string separator)
+    private LdapException GetLdapException()
     {
-        //Arrange
-        var sensitiveData = GetConfig(config, separator);
-        var formatterProviderMock = new LdapBindNameFormatterProvider([]);
-        var processor = new LdapFirstFactorProcessor(new CustomLdapConnectionFactory(), formatterProviderMock, NullLogger<LdapFirstFactorProcessor>.Instance);
-        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
-        var packetMock = new Mock<IRadiusPacket>();
-        var serverSettings = new Mock<ILdapServerConfiguration>();
-        var authState = new AuthenticationState();
-        var transformRules = new UserNameTransformRules();
-        packetMock.Setup(x => x.UserName).Returns("userName");
-        packetMock.Setup(x => x.TryGetUserPassword()).Returns(sensitiveData["Password"]);
-        contextMock.Setup(x => x.RequestPacket).Returns(packetMock.Object);
-        serverSettings.Setup(x => x.ConnectionString).Returns(sensitiveData["ConnectionString"]);
-        serverSettings.Setup(x => x.BindTimeoutInSeconds).Returns(30);
-        contextMock.Setup(x => x.LdapServerConfiguration).Returns(serverSettings.Object);
-        contextMock.Setup(x => x.AuthenticationState).Returns(authState);
-        contextMock.Setup(x => x.UserNameTransformRules).Returns(transformRules);
-        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
-        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
-        
-        //Act
-        await processor.ProcessFirstFactor(contextMock.Object);
-        
-        //Assert
-        Assert.Equal(AuthenticationStatus.Reject, authState.FirstFactorStatus);
-    }
-
-    private Dictionary<string, string> GetConfig(string config, string separator)
-    {
-        return ConfigUtils.GetConfigSensitiveData(config, separator);
+        var ex = new LdapException(1, "message", "data 773");
+        return ex;
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/ActiveDirectoryTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/ActiveDirectoryTests.cs
@@ -1,0 +1,24 @@
+using Moq;
+using Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+
+namespace Multifactor.Radius.Adapter.v2.Tests.Unit.LdapBindNameFormatterTests;
+
+public class ActiveDirectoryTests
+{
+    [Fact]
+    public void FormatName_ShouldReturnSameName()
+    {
+        //Arrange
+        var formatter = new ActiveDirectoryFormatter();
+
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/FreeIpaTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/FreeIpaTests.cs
@@ -1,0 +1,73 @@
+using Moq;
+using Multifactor.Core.Ldap.Name;
+using Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+
+namespace Multifactor.Radius.Adapter.v2.Tests.Unit.LdapBindNameFormatterTests;
+
+public class FreeIpaTests
+{
+    [Fact]
+    public void FormatName_Uid_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new FreeIpaFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var dn = new DistinguishedName("cn=user,dc=domain,dc=com");
+        profileMock.Setup(x => x.Dn).Returns(dn);
+        var name = "userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(dn.StringRepresentation, result);
+    }
+    
+    [Fact]
+    public void FormatName_NetBiosName_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new FreeIpaFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var dn = new DistinguishedName("cn=user,dc=domain,dc=com");
+        profileMock.Setup(x => x.Dn).Returns(dn);
+        var name = "domain\\userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(dn.StringRepresentation, result);
+    }
+    
+    [Fact]
+    public void FormatName_Dn_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new FreeIpaFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "dc=domain,dc=com";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+    
+    [Fact]
+    public void FormatName_Upn_ShouldReturnUpn()
+    {
+        //Arrange
+        var formatter = new FreeIpaFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "user@domain";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/LdapBindNameFormatterProviderTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/LdapBindNameFormatterProviderTests.cs
@@ -1,0 +1,49 @@
+using Moq;
+using Multifactor.Core.Ldap.Schema;
+using Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+namespace Multifactor.Radius.Adapter.v2.Tests.Unit.LdapBindNameFormatterTests;
+
+public class LdapBindNameFormatterProviderTests
+{
+    [Theory]
+    [InlineData(LdapImplementation.ActiveDirectory)]
+    [InlineData(LdapImplementation.OpenLDAP)]
+    [InlineData(LdapImplementation.Samba)]
+    [InlineData(LdapImplementation.FreeIPA)]
+    [InlineData(LdapImplementation.MultiDirectory)]
+    public void GetLdapBindNameFormatter_ShouldReturnRequiredFormatter(LdapImplementation ldapImplementation)
+    {
+        //Arrange
+        var processor = new Mock<ILdapBindNameFormatter>();
+        processor.Setup(x => x.LdapImplementation).Returns(ldapImplementation);
+        var provider = new LdapBindNameFormatterProvider([processor.Object]);
+        
+        //Act
+        var formatter = provider.GetLdapBindNameFormatter(ldapImplementation);
+        
+        //Assert
+        Assert.NotNull(formatter);
+        Assert.Equal(ldapImplementation, formatter.LdapImplementation);
+    }
+    
+    [Theory]
+    [InlineData(LdapImplementation.ActiveDirectory)]
+    [InlineData(LdapImplementation.OpenLDAP)]
+    [InlineData(LdapImplementation.Samba)]
+    [InlineData(LdapImplementation.FreeIPA)]
+    [InlineData(LdapImplementation.MultiDirectory)]
+    public void GetLdapBindNameFormatter_NoSuchFormatter_ShouldReturnNull(LdapImplementation ldapImplementation)
+    {
+        //Arrange
+        var processor = new Mock<ILdapBindNameFormatter>();
+        processor.Setup(x => x.LdapImplementation).Returns(LdapImplementation.Unknown);
+        var provider = new LdapBindNameFormatterProvider([processor.Object]);
+        
+        //Act
+        var formatter = provider.GetLdapBindNameFormatter(ldapImplementation);
+        
+        //Assert
+        Assert.Null(formatter);
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/MultiDirectoryTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/MultiDirectoryTests.cs
@@ -1,0 +1,73 @@
+using Moq;
+using Multifactor.Core.Ldap.Name;
+using Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+
+namespace Multifactor.Radius.Adapter.v2.Tests.Unit.LdapBindNameFormatterTests;
+
+public class MultiDirectoryTests
+{
+    [Fact]
+    public void FormatName_Uid_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new MultiDirectoryFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var dn = new DistinguishedName("cn=user,dc=domain,dc=com");
+        profileMock.Setup(x => x.Dn).Returns(dn);
+        var name = "userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(dn.StringRepresentation, result);
+    }
+    
+    [Fact]
+    public void FormatName_NetBiosName_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new MultiDirectoryFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var dn = new DistinguishedName("cn=user,dc=domain,dc=com");
+        profileMock.Setup(x => x.Dn).Returns(dn);
+        var name = "domain\\userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(dn.StringRepresentation, result);
+    }
+    
+    [Fact]
+    public void FormatName_Dn_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new MultiDirectoryFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "dc=domain,dc=com";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+    
+    [Fact]
+    public void FormatName_Upn_ShouldReturnUpn()
+    {
+        //Arrange
+        var formatter = new MultiDirectoryFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "user@domain";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/OpenLdapTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/OpenLdapTests.cs
@@ -1,0 +1,73 @@
+using Moq;
+using Multifactor.Core.Ldap.Name;
+using Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+
+namespace Multifactor.Radius.Adapter.v2.Tests.Unit.LdapBindNameFormatterTests;
+
+public class OpenLdapTests
+{
+    [Fact]
+    public void FormatName_Uid_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new OpenLdapFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var dn = new DistinguishedName("cn=user,dc=domain,dc=com");
+        profileMock.Setup(x => x.Dn).Returns(dn);
+        var name = "userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(dn.StringRepresentation, result);
+    }
+    
+    [Fact]
+    public void FormatName_NetBiosName_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new OpenLdapFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var dn = new DistinguishedName("cn=user,dc=domain,dc=com");
+        profileMock.Setup(x => x.Dn).Returns(dn);
+        var name = "domain\\userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(dn.StringRepresentation, result);
+    }
+    
+    [Fact]
+    public void FormatName_Dn_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new OpenLdapFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "dc=domain,dc=com";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+    
+    [Fact]
+    public void FormatName_Upn_ShouldReturnUpn()
+    {
+        //Arrange
+        var formatter = new OpenLdapFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "user@domain";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/SambaTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/LdapBindNameFormatterTests/SambaTests.cs
@@ -1,0 +1,73 @@
+using Moq;
+using Multifactor.Core.Ldap.Name;
+using Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+
+namespace Multifactor.Radius.Adapter.v2.Tests.Unit.LdapBindNameFormatterTests;
+
+public class SambaTests
+{
+    [Fact]
+    public void FormatName_Uid_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new SambaFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var dn = new DistinguishedName("cn=user,dc=domain,dc=com");
+        profileMock.Setup(x => x.Dn).Returns(dn);
+        var name = "userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(dn.StringRepresentation, result);
+    }
+    
+    [Fact]
+    public void FormatName_NetBiosName_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new SambaFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var dn = new DistinguishedName("cn=user,dc=domain,dc=com");
+        profileMock.Setup(x => x.Dn).Returns(dn);
+        var name = "domain\\userName";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(dn.StringRepresentation, result);
+    }
+    
+    [Fact]
+    public void FormatName_Dn_ShouldReturnDn()
+    {
+        //Arrange
+        var formatter = new SambaFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "dc=domain,dc=com";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+    
+    [Fact]
+    public void FormatName_Upn_ShouldReturnUpn()
+    {
+        //Arrange
+        var formatter = new SambaFormatter();
+        var profileMock = new Mock<ILdapProfile>();
+        var name = "user@domain";
+        
+        //Act
+        var result = formatter.FormatName(name, profileMock.Object);
+        
+        //Assert
+        Assert.Equal(name, result);
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/ActiveDirectoryFormatter.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/ActiveDirectoryFormatter.cs
@@ -1,0 +1,14 @@
+using Multifactor.Core.Ldap.Schema;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+
+namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+public class ActiveDirectoryFormatter : ILdapBindNameFormatter
+{
+    public LdapImplementation LdapImplementation => LdapImplementation.ActiveDirectory;
+    
+    public string FormatName(string userName, ILdapProfile ldapProfile)
+    {
+        return userName;
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/FreeIpaFormatter.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/FreeIpaFormatter.cs
@@ -1,0 +1,21 @@
+using Multifactor.Core.Ldap.Schema;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+using Multifactor.Radius.Adapter.v2.Core.Ldap.Identity;
+
+namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+public class FreeIpaFormatter : ILdapBindNameFormatter
+{
+    public LdapImplementation LdapImplementation => LdapImplementation.FreeIPA;
+    
+    public string FormatName(string userName, ILdapProfile ldapProfile)
+    {
+        var identity = new UserIdentity(userName);
+        
+        if (identity.Format == UserIdentityFormat.UserPrincipalName 
+            || identity.Format == UserIdentityFormat.DistinguishedName)
+            return userName;
+
+        return ldapProfile.Dn.StringRepresentation;
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/ILdapBindNameFormatter.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/ILdapBindNameFormatter.cs
@@ -1,0 +1,10 @@
+using Multifactor.Core.Ldap.Schema;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+
+namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+public interface ILdapBindNameFormatter
+{
+    LdapImplementation LdapImplementation { get; }
+    string FormatName(string userName, ILdapProfile ldapProfile);
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/ILdapBindNameFormatterProvider.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/ILdapBindNameFormatterProvider.cs
@@ -1,0 +1,8 @@
+using Multifactor.Core.Ldap.Schema;
+
+namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+public interface ILdapBindNameFormatterProvider
+{
+    ILdapBindNameFormatter? GetLdapBindNameFormatter(LdapImplementation ldapImplementation);
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/LdapBindNameFormatterProvider.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/LdapBindNameFormatterProvider.cs
@@ -1,0 +1,18 @@
+using Multifactor.Core.Ldap.Schema;
+
+namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+public class LdapBindNameFormatterProvider : ILdapBindNameFormatterProvider
+{
+    private readonly List<ILdapBindNameFormatter> _formatters = new();
+    
+    public LdapBindNameFormatterProvider(IEnumerable<ILdapBindNameFormatter> formatters)
+    {
+        _formatters.AddRange(formatters);
+    }
+
+    public ILdapBindNameFormatter? GetLdapBindNameFormatter(LdapImplementation ldapImplementation)
+    {
+        return _formatters.FirstOrDefault(f => f.LdapImplementation == ldapImplementation);
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/MultiDirectoryFormatter.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/MultiDirectoryFormatter.cs
@@ -1,0 +1,21 @@
+using Multifactor.Core.Ldap.Schema;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+using Multifactor.Radius.Adapter.v2.Core.Ldap.Identity;
+
+namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+public class MultiDirectoryFormatter : ILdapBindNameFormatter
+{
+    public LdapImplementation LdapImplementation => LdapImplementation.MultiDirectory;
+    
+    public string FormatName(string userName, ILdapProfile ldapProfile)
+    {
+        var identity = new UserIdentity(userName);
+        
+        if (identity.Format == UserIdentityFormat.UserPrincipalName 
+            || identity.Format == UserIdentityFormat.DistinguishedName)
+            return userName;
+
+        return ldapProfile.Dn.StringRepresentation;
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/OpenLdapFormatter.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/OpenLdapFormatter.cs
@@ -1,0 +1,21 @@
+using Multifactor.Core.Ldap.Schema;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+using Multifactor.Radius.Adapter.v2.Core.Ldap.Identity;
+
+namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+public class OpenLdapFormatter: ILdapBindNameFormatter
+{
+    public LdapImplementation LdapImplementation => LdapImplementation.OpenLDAP;
+    
+    public string FormatName(string userName, ILdapProfile ldapProfile)
+    {
+        var identity = new UserIdentity(userName);
+        
+        if (identity.Format == UserIdentityFormat.UserPrincipalName 
+            || identity.Format == UserIdentityFormat.DistinguishedName)
+            return userName;
+
+        return ldapProfile.Dn.StringRepresentation;
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/SambaFormatter.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/BindNameFormat/SambaFormatter.cs
@@ -1,0 +1,21 @@
+using Multifactor.Core.Ldap.Schema;
+using Multifactor.Radius.Adapter.v2.Core.Ldap;
+using Multifactor.Radius.Adapter.v2.Core.Ldap.Identity;
+
+namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
+
+public class SambaFormatter : ILdapBindNameFormatter
+{
+    public LdapImplementation LdapImplementation => LdapImplementation.Samba;
+    
+    public string FormatName(string userName, ILdapProfile ldapProfile)
+    {
+        var identity = new UserIdentity(userName);
+        
+        if (identity.Format == UserIdentityFormat.UserPrincipalName 
+            || identity.Format == UserIdentityFormat.DistinguishedName)
+            return userName;
+
+        return ldapProfile.Dn.StringRepresentation;
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/LdapFirstFactorProcessor.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/FirstFactor/LdapFirstFactorProcessor.cs
@@ -5,6 +5,7 @@ using Multifactor.Core.Ldap.Connection;
 using Multifactor.Core.Ldap.LangFeatures;
 using Multifactor.Radius.Adapter.v2.Core.Auth;
 using Multifactor.Radius.Adapter.v2.Core.Configuration.Client;
+using Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
 using Multifactor.Radius.Adapter.v2.Core.Ldap;
 using Multifactor.Radius.Adapter.v2.Infrastructure.Pipeline.Context;
 using ILdapConnectionFactory = Multifactor.Radius.Adapter.v2.Core.Ldap.ILdapConnectionFactory;
@@ -13,19 +14,20 @@ namespace Multifactor.Radius.Adapter.v2.Core.FirstFactor;
 
 public class LdapFirstFactorProcessor : IFirstFactorProcessor
 {
-    private ILdapConnectionFactory _ldapConnectionFactory;
-    private ILogger _logger;
+    private readonly ILdapConnectionFactory _ldapConnectionFactory;
+    private readonly ILdapBindNameFormatterProvider _ldapBindNameFormatterProvider;
+    private readonly ILogger<LdapFirstFactorProcessor> _logger;
 
     public AuthenticationSource AuthenticationSource => AuthenticationSource.Ldap;
 
-    public LdapFirstFactorProcessor(ILdapConnectionFactory ldapConnectionFactory,
-        ILogger<LdapFirstFactorProcessor> logger)
+    public LdapFirstFactorProcessor(ILdapConnectionFactory ldapConnectionFactory, ILdapBindNameFormatterProvider ldapBindNameFormatterProvider, ILogger<LdapFirstFactorProcessor> logger)
     {
         Throw.IfNull(ldapConnectionFactory, nameof(ldapConnectionFactory));
         Throw.IfNull(logger, nameof(logger));
 
         _ldapConnectionFactory = ldapConnectionFactory;
         _logger = logger;
+        _ldapBindNameFormatterProvider = ldapBindNameFormatterProvider;
     }
 
     public Task ProcessFirstFactor(IRadiusPipelineExecutionContext context)
@@ -80,11 +82,28 @@ public class LdapFirstFactorProcessor : IFirstFactorProcessor
         string password)
     {
         var serverConfig = context.LdapServerConfiguration;
+        if (serverConfig is null)
+            throw new InvalidOperationException("No Ldap servers configured.");
+        
+        var bindName = string.Empty;
+        
         try
         {
+            var ldapImpl = context.LdapSchema!.LdapServerImplementation;
+            var formatter = _ldapBindNameFormatterProvider.GetLdapBindNameFormatter(ldapImpl);
+            if (formatter is null)
+                _logger.LogWarning("No LDAP bind name formatter configured for '{implementation}' implementation.", ldapImpl);
+
+            var formatted = string.Empty;
+            if (context.UserLdapProfile is not null)
+                formatted = formatter?.FormatName(login, context.UserLdapProfile);
+            
+            bindName = string.IsNullOrWhiteSpace(formatted) ? login : formatted;
+            
+            _logger.LogDebug("Use '{name}' for LDAP bind.", bindName);
             using var connection = GetConnection(
                 serverConfig.ConnectionString,
-                login,
+                bindName,
                 password,
                 serverConfig.BindTimeoutInSeconds);
 
@@ -94,7 +113,7 @@ public class LdapFirstFactorProcessor : IFirstFactorProcessor
         {
             if (ex is not LdapException ldapException)
             {
-                _logger.LogError(ex, "Verification user '{user:l}' at {ldapUri:l} failed", login, serverConfig.ConnectionString);
+                _logger.LogError(ex, "Verification user '{user:l}' at {ldapUri:l} failed", bindName, serverConfig.ConnectionString);
                 return false;
             }
 
@@ -102,7 +121,7 @@ public class LdapFirstFactorProcessor : IFirstFactorProcessor
             if (info != null)
                 ProcessErrorReason(info, context, serverConfig);
 
-            _logger.LogWarning(ldapException, "Verification user '{user:l}' at {ldapUri:l} failed: {dataReason:l}", login, serverConfig.ConnectionString, info?.ReasonText);
+            _logger.LogWarning(ldapException, "Verification user '{user:l}' at {ldapUri:l} failed: {dataReason:l}", bindName, serverConfig.ConnectionString, info?.ReasonText);
         }
 
         return false;

--- a/src/Multifactor.Radius.Adapter.v2/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Multifactor.Radius.Adapter.v2.Core.Configuration.Client.Build;
 using Multifactor.Radius.Adapter.v2.Core.Configuration.Service;
 using Multifactor.Radius.Adapter.v2.Core.Configuration.Service.Build;
 using Multifactor.Radius.Adapter.v2.Core.FirstFactor;
+using Multifactor.Radius.Adapter.v2.Core.FirstFactor.BindNameFormat;
 using Multifactor.Radius.Adapter.v2.Core.Ldap;
 using Multifactor.Radius.Adapter.v2.Core.Radius.Attributes;
 using Multifactor.Radius.Adapter.v2.Infrastructure.Configuration.RadiusAdapter.Build;
@@ -213,6 +214,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IRadiusReplyAttributeService, RadiusReplyAttributeService>();
         services.AddTransient<IRadiusAttributeTypeConverter, RadiusAttributeTypeConverter>();
         services.AddSingleton<ICacheService, CacheService>();
+        AddLdapBindNameFormation(services);
     }
 
     public static void AddAdapterLogging(this IServiceCollection services)
@@ -222,5 +224,15 @@ public static class ServiceCollectionExtensions
         Log.Logger = logger;
 
         services.AddSerilog();
+    }
+
+    private static void AddLdapBindNameFormation(IServiceCollection services)
+    {
+        services.AddSingleton<ILdapBindNameFormatterProvider, LdapBindNameFormatterProvider>();
+        services.AddTransient<ILdapBindNameFormatter, ActiveDirectoryFormatter>();
+        services.AddTransient<ILdapBindNameFormatter, FreeIpaFormatter>();
+        services.AddTransient<ILdapBindNameFormatter, MultiDirectoryFormatter>();
+        services.AddTransient<ILdapBindNameFormatter, OpenLdapFormatter>();
+        services.AddTransient<ILdapBindNameFormatter, SambaFormatter>();
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Services/Ldap/LdapProfileService.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/Ldap/LdapProfileService.cs
@@ -41,6 +41,7 @@ public class LdapProfileService : ILdapProfileService
         }
 
         var filter = GetFilter(identityToSearch, request.LdapSchema);
+        _logger.LogDebug("Search base = '{searchBase}'. Filter for search = '{filter}'", request.SearchBase.StringRepresentation, filter);
         var loader = new LdapProfileLoader(request.SearchBase, connection, request.LdapSchema);
         return loader.LoadLdapProfile(filter, attributeNames: request.AttributeNames ?? []);
     }


### PR DESCRIPTION
1. Добавил формат для bind имени каждого LDAP каталога.
2. Перед реальным bind происходит форматирование имени, сейчас все каталоги кроме AD делают bind с UPN или DN. AD может и по Uid (samAccountName) делать bind.
3. Добавил тесты на формат
4. Перенес в папку Unit часть тестов из LdapFirstFactorProcessorTests.cs. Перенесенные тесты работают всегда и везде. В файле LdapFirstFactorProcessorTests.cs остались тесты, проверяющие реальный bind в каталог, для них нужны файлы с кредами
5. Расширил LdapFirstFactorProcessorTests.cs  тесты для работы с несколькими каталогами, добавил тест FreeIpa
  