### PR TITLE
DEV-847

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/FirstFactorTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/FirstFactorTests.cs
@@ -63,6 +63,59 @@ public class FirstFactorTests(RadiusFixtures radiusFixtures) : E2ETestBase(radiu
         Assert.Single(mfAPiMock.Invocations);
         Assert.Equal(PacketCode.AccessAccept, response.Code);
     }
+    
+    [Theory]
+    [InlineData("ad-root-conf.env", AccountType.Microsoft)]
+    [InlineData("radius-root-conf.env", AccountType.Microsoft)]
+    [InlineData("ad-root-conf.env", AccountType.Local)]
+    [InlineData("radius-root-conf.env", AccountType.Local)]
+    [InlineData("ad-root-conf.env", AccountType.Unknown)]
+    [InlineData("radius-root-conf.env", AccountType.Unknown)]
+    public async Task BST016_NotDomainAccount_ShouldAccept(string configName, AccountType accountType)
+    {
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+
+        var mfAPiMock = new Mock<IMultifactorApiService>();
+
+        mfAPiMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept));
+
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(mfAPiMock.Object);
+        };
+        
+        var serverSection = new LdapServersSection()
+        {
+            LdapServer = new LdapServerConfiguration()
+            {
+                ConnectionString =
+                    sensitiveData.GetConfigValue("root", nameof(LdapServerConfiguration.ConnectionString))!,
+                UserName = RadiusAdapterConstants.AdminUserName,
+                Password = RadiusAdapterConstants.AdminUserPassword,
+            }
+        };
+        
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, serverSection);
+
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)accountType);
+        
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Single(mfAPiMock.Invocations);
+        Assert.Equal(PacketCode.AccessAccept, response.Code);
+    }
 
     [Theory]
     [InlineData("ad-root-conf.env")]

--- a/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/PreSecondFactorTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/PreSecondFactorTests.cs
@@ -69,6 +69,121 @@ public class PreSecondFactorTests(RadiusFixtures radiusFixtures) : E2ETestBase(r
         Assert.Equal(PacketCode.AccessAccept, response.Code);
         Assert.False(response.Attributes.ContainsKey("State"));
     }
+    
+    [Theory]
+    [InlineData("none-root-conf.env")]
+    [InlineData("ad-root-conf.env")]
+    [InlineData("radius-root-conf.env")]
+    public async Task BST021_DomainUser_ShouldAccept(string configName)
+    {
+        var state = "BST021_ShouldAccept";
+        
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+        
+        var mfAPiMock = new Mock<IMultifactorApiService>();
+        
+        mfAPiMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept, state));
+        
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(mfAPiMock.Object);
+        };
+
+        var ldapServersSection = new LdapServersSection()
+        {
+            LdapServer = new LdapServerConfiguration()
+            {
+                ConnectionString =
+                    sensitiveData.GetConfigValue("root", nameof(LdapServerConfiguration.ConnectionString))!,
+                UserName = RadiusAdapterConstants.AdminUserName,
+                Password = RadiusAdapterConstants.AdminUserPassword
+            }
+        };
+        
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, ldapServersSection);
+        
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+        
+        // AccessRequest step 1
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        
+        //Should check groups
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)AccountType.Domain);
+        
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Single(mfAPiMock.Invocations);
+        Assert.Equal(PacketCode.AccessAccept, response.Code);
+        Assert.False(response.Attributes.ContainsKey("State"));
+    }
+    
+    [Theory]
+    [InlineData("none-root-conf.env", AccountType.Microsoft)]
+    [InlineData("none-root-conf.env", AccountType.Local)]
+    [InlineData("ad-root-conf.env", AccountType.Microsoft)]
+    [InlineData("ad-root-conf.env", AccountType.Local)]
+    [InlineData("radius-root-conf.env", AccountType.Microsoft)]
+    [InlineData("radius-root-conf.env", AccountType.Local)]
+    public async Task BST021_NotDomainUser_ShouldAccept(string configName, AccountType accountType)
+    {
+        var state = "BST021_ShouldAccept";
+        
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+        
+        var mfAPiMock = new Mock<IMultifactorApiService>();
+        
+        mfAPiMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept, state));
+        
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(mfAPiMock.Object);
+        };
+
+        var ldapServersSection = new LdapServersSection()
+        {
+            LdapServer = new LdapServerConfiguration()
+            {
+                ConnectionString =
+                    sensitiveData.GetConfigValue("root", nameof(LdapServerConfiguration.ConnectionString))!,
+                UserName = RadiusAdapterConstants.AdminUserName,
+                Password = RadiusAdapterConstants.AdminUserPassword
+            }
+        };
+        
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, ldapServersSection);
+        
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+        
+        // AccessRequest step 1
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        
+        //Should not check groups
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)accountType);
+        
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Single(mfAPiMock.Invocations);
+        Assert.Equal(PacketCode.AccessAccept, response.Code);
+        Assert.False(response.Attributes.ContainsKey("State"));
+    }
 
     [Theory]
     [InlineData("none-root-conf.env")]

--- a/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/SingleActiveDirectory2FaBypassGroupTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/SingleActiveDirectory2FaBypassGroupTests.cs
@@ -87,6 +87,83 @@ public class SingleActiveDirectory2FaBypassGroupTests(RadiusFixtures radiusFixtu
         Assert.Single(secondFactorMock.Invocations);
         Assert.Equal(PacketCode.AccessAccept, response.Code);
     }
+    
+    [Theory]
+    [InlineData("ad-root-conf.env")]
+    public async Task BST014_DomainUser_ShouldAccept(string configName)
+    {
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+
+        var secondFactorMock = new Mock<IMultifactorApiService>();
+
+        secondFactorMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept));
+
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(secondFactorMock.Object);
+        };
+
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, sensitiveData.GetConfigValue("root", "AccessGroups")!);
+
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        //Should check groups
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)AccountType.Domain);
+        
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Empty(secondFactorMock.Invocations);
+        Assert.Equal(PacketCode.AccessAccept, response.Code);
+    }
+    
+    [Theory]
+    [InlineData("ad-root-conf.env", AccountType.Microsoft)]
+    [InlineData("ad-root-conf.env", AccountType.Local)]
+    public async Task BST014_NotDomainUser_ShouldAccept(string configName, AccountType accountType)
+    {
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+
+        var secondFactorMock = new Mock<IMultifactorApiService>();
+
+        secondFactorMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept));
+
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(secondFactorMock.Object);
+        };
+
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, sensitiveData.GetConfigValue("root", "AccessGroups")!);
+
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        //Should not check groups
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)accountType);
+        
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Single(secondFactorMock.Invocations);
+        Assert.Equal(PacketCode.AccessAccept, response.Code);
+    }
 
     private RadiusAdapterConfiguration CreateRadiusConfiguration(
         ConfigSensitiveData[] sensitiveData,

--- a/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/SingleActiveDirectory2FaGroupTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/SingleActiveDirectory2FaGroupTests.cs
@@ -87,6 +87,83 @@ public class SingleActiveDirectory2FaGroupTests(RadiusFixtures radiusFixtures) :
         Assert.Single(secondFactorMock.Invocations);
         Assert.Equal(PacketCode.AccessAccept, response.Code);
     }
+    
+    [Theory]
+    [InlineData("ad-root-conf.env")]
+    public async Task BST011_DomainUser_ShouldAccept(string configName)
+    {
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+        
+        var secondFactorMock = new Mock<IMultifactorApiService>();
+
+        secondFactorMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept));
+
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(secondFactorMock.Object);
+        };
+        
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, sensitiveData.GetConfigValue("root", "AccessGroups")!);
+        
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        //Should check groups
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)AccountType.Domain);
+
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Single(secondFactorMock.Invocations);
+        Assert.Equal(PacketCode.AccessAccept, response.Code);
+    }
+    
+    [Theory]
+    [InlineData("ad-root-conf.env", AccountType.Microsoft)]
+    [InlineData("ad-root-conf.env", AccountType.Local)]
+    public async Task BST011_NotDomainUser_ShouldAccept(string configName, AccountType accountType)
+    {
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+        
+        var secondFactorMock = new Mock<IMultifactorApiService>();
+
+        secondFactorMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept));
+
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(secondFactorMock.Object);
+        };
+        
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, sensitiveData.GetConfigValue("root", "AccessGroups")!);
+        
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        //Should not check groups
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)accountType);
+
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Single(secondFactorMock.Invocations);
+        Assert.Equal(PacketCode.AccessAccept, response.Code);
+    }
 
     private RadiusAdapterConfiguration CreateRadiusConfiguration(
         ConfigSensitiveData[] sensitiveData,

--- a/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/SingleActiveDirectoryGroupTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.EndToEndTests/Tests/SingleActiveDirectoryGroupTests.cs
@@ -123,6 +123,86 @@ public class SingleActiveDirectoryGroupTests(RadiusFixtures radiusFixtures) : E2
         Assert.Empty(secondFactorMock.Invocations);
         Assert.Equal(PacketCode.AccessReject, response.Code);
     }
+    
+    [Theory]
+    [InlineData("ad-root-conf.env")]
+    [InlineData("none-root-conf.env")]
+    public async Task BST008_DomainUser_ShouldReject(string configName)
+    {
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+
+        var secondFactorMock = new Mock<IMultifactorApiService>();
+
+        secondFactorMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept));
+
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(secondFactorMock.Object);
+        };
+        
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, "cn=Not,dc=Existed,dc=Group");
+        
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        //Should check groups
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)AccountType.Domain);
+        
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Empty(secondFactorMock.Invocations);
+        Assert.Equal(PacketCode.AccessReject, response.Code);
+    }
+    
+    [Theory]
+    [InlineData("ad-root-conf.env", AccountType.Microsoft)]
+    [InlineData("ad-root-conf.env", AccountType.Local)]
+    [InlineData("none-root-conf.env", AccountType.Microsoft)]
+    [InlineData("none-root-conf.env", AccountType.Local)]
+    public async Task BST008_NotDomainUser_ShouldAccept(string configName, AccountType accountType)
+    {
+        var sensitiveData =
+            E2ETestsUtils.GetConfigSensitiveData(configName);
+
+        var secondFactorMock = new Mock<IMultifactorApiService>();
+
+        secondFactorMock
+            .Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()))
+            .ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Accept));
+
+        var hostConfiguration = (HostApplicationBuilder builder) =>
+        {
+            builder.Services.ReplaceService(secondFactorMock.Object);
+        };
+        
+        var rootConfig = CreateRadiusConfiguration(sensitiveData, "cn=Not,dc=Existed,dc=Group");
+        
+        await StartHostAsync(
+            rootConfig,
+            configure: hostConfiguration);
+
+        var accessRequest = CreateRadiusPacket(PacketCode.AccessRequest);
+        accessRequest.AddAttributeValue("NAS-Identifier", RadiusAdapterConstants.DefaultNasIdentifier);
+        accessRequest.AddAttributeValue("User-Name", RadiusAdapterConstants.BindUserName);
+        accessRequest.AddAttributeValue("User-Password", RadiusAdapterConstants.BindUserPassword);
+        //Should not check groups
+        accessRequest.AddAttributeValue("Acct-Authentic", (uint)accountType);
+        
+        var response = SendPacketAsync(accessRequest);
+
+        Assert.NotNull(response);
+        Assert.Single(secondFactorMock.Invocations);
+        Assert.Equal(PacketCode.AccessAccept, response.Code);
+    }
 
     private RadiusAdapterConfiguration CreateRadiusConfiguration(
         ConfigSensitiveData[] sensitiveData,

--- a/src/Multifactor.Radius.Adapter.v2.Tests/LdapProfile/LdapProfileServiceTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/LdapProfile/LdapProfileServiceTests.cs
@@ -118,7 +118,7 @@ public class LdapProfileServiceTests
 [Collection("LDAP")]
 public class FreeIpaLdapProfileServiceTests
 {
-    [Fact]
+    //[Fact]
     public void LoadProfile_ByUid_ShouldLoadProfile()
     {
         var sensitiveData = GetConfig();

--- a/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/AccessGroupsCheckingStepTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/AccessGroupsCheckingStepTests.cs
@@ -6,6 +6,7 @@ using Multifactor.Radius.Adapter.v2.Core.Auth;
 using Multifactor.Radius.Adapter.v2.Core.Configuration.Client;
 using Multifactor.Radius.Adapter.v2.Core.Ldap;
 using Multifactor.Radius.Adapter.v2.Core.Pipeline;
+using Multifactor.Radius.Adapter.v2.Core.Radius.Packet;
 using Multifactor.Radius.Adapter.v2.Infrastructure.Pipeline.Context;
 using Multifactor.Radius.Adapter.v2.Infrastructure.Pipeline.Steps;
 using Multifactor.Radius.Adapter.v2.Services.Ldap;
@@ -33,6 +34,7 @@ public class AccessGroupsCheckingStepTests
         
         Assert.False(execState.IsTerminated);
         Assert.False(execState.ShouldSkipResponse);
+        groupService.Verify(x => x.LoadUserGroups(It.IsAny<LoadUserGroupsRequest>()), Times.Never);
     }
     
     [Fact]
@@ -63,9 +65,11 @@ public class AccessGroupsCheckingStepTests
         var step = new AccessGroupsCheckingStep(groupService.Object, NullLogger<AccessGroupsCheckingStep>.Instance);
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         var serverConfigMock = new Mock<ILdapServerConfiguration>();
+        serverConfigMock.Setup(x => x.AccessGroups).Returns(["group"]);
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(serverConfigMock.Object);
         contextMock.Setup(x => x.UserLdapProfile).Returns(() => null);
         contextMock.Setup(x => x.LdapSchema).Returns(() => new Mock<ILdapSchema>().Object);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         var context = contextMock.Object;
         
         await Assert.ThrowsAsync<ArgumentNullException>(() => step.ExecuteAsync(context));
@@ -111,6 +115,7 @@ public class AccessGroupsCheckingStepTests
         contextMock.Setup(x => x.LdapSchema).Returns(() => new Mock<ILdapSchema>().Object);
         contextMock.Setup(x => x.ExecutionState).Returns(execState);
         contextMock.SetupProperty(x => x.AuthenticationState);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         var context = contextMock.Object;
         context.AuthenticationState = new AuthenticationState();
         
@@ -142,6 +147,7 @@ public class AccessGroupsCheckingStepTests
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(serverConfigMock.Object);
         contextMock.Setup(x => x.UserLdapProfile).Returns(() => profileMock.Object);
         contextMock.Setup(x => x.LdapSchema).Returns(() => new Mock<ILdapSchema>().Object);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         
         var execState = new ExecutionState();
         contextMock.Setup(x => x.ExecutionState).Returns(execState);
@@ -151,5 +157,35 @@ public class AccessGroupsCheckingStepTests
         
         Assert.False(execState.IsTerminated);
         Assert.False(execState.ShouldSkipResponse);
+    }
+    
+    [Fact]
+    public async Task CheckAccessGroups_NotDomainAccount_ShouldSkipGroupCheck()
+    {
+        //Arrange
+        var groupService = new Mock<ILdapGroupService>();
+        var step = new AccessGroupsCheckingStep(groupService.Object, NullLogger<AccessGroupsCheckingStep>.Instance);
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        var serverConfigMock = new Mock<ILdapServerConfiguration>();
+        var execState = new ExecutionState();
+        serverConfigMock.Setup(x => x.AccessGroups).Returns(["group"]);
+        contextMock.Setup(x => x.LdapServerConfiguration).Returns(serverConfigMock.Object);
+        contextMock.Setup(x => x.UserLdapProfile).Returns(() => new Mock<ILdapProfile>().Object);
+        contextMock.Setup(x => x.LdapSchema).Returns(() => new Mock<ILdapSchema>().Object);
+        contextMock.Setup(x => x.ExecutionState).Returns(execState);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(false);
+        var packetMock = new Mock<IRadiusPacket>();
+        packetMock.Setup(x=> x.AccountType).Returns(AccountType.Unknown);
+        packetMock.Setup(x=> x.UserName).Returns("username");
+        contextMock.Setup(x => x.RequestPacket).Returns(packetMock.Object);
+        var context = contextMock.Object;
+        
+        //Act
+        await step.ExecuteAsync(context);
+        
+        //Assert
+        Assert.False(execState.IsTerminated);
+        Assert.False(execState.ShouldSkipResponse);
+        groupService.Verify(x => x.LoadUserGroups(It.IsAny<LoadUserGroupsRequest>()), Times.Never);
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/ProfileLoadingStepTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/ProfileLoadingStepTests.cs
@@ -14,7 +14,7 @@ using Multifactor.Radius.Adapter.v2.Tests.Fixture;
 
 namespace Multifactor.Radius.Adapter.v2.Tests.PipelineTests.StepsTests;
 
-public class ProfileLoadingTests
+public class ProfileLoadingStepTests
 {
     [Fact]
     public async Task ExecStep_ShouldLoadProfile()
@@ -36,6 +36,7 @@ public class ProfileLoadingTests
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(serverConfig.Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("name");
         contextMock.SetupProperty(x => x.UserLdapProfile);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         var context = contextMock.Object;
         var cacheMock = new Mock<ICacheService>();
         
@@ -61,6 +62,7 @@ public class ProfileLoadingTests
         contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:666"));
         contextMock.SetupProperty(x => x.UserLdapProfile);
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(new Mock<ILdapServerConfiguration>().Object);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         var context = contextMock.Object;
         var cacheMock = new Mock<ICacheService>();
         var step = new ProfileLoadingStep(loaderMock.Object, cacheMock.Object, NullLogger<ProfileLoadingStep>.Instance);
@@ -87,6 +89,7 @@ public class ProfileLoadingTests
         serverConfig.Setup(x => x.PhoneAttributes).Returns([]);
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(serverConfig.Object);
         contextMock.SetupProperty(x => x.UserLdapProfile);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         var context = contextMock.Object;
         var cacheMock = new Mock<ICacheService>();
         var step = new ProfileLoadingStep(loaderMock.Object, cacheMock.Object, NullLogger<ProfileLoadingStep>.Instance);
@@ -109,12 +112,42 @@ public class ProfileLoadingTests
         contextMock.Setup(x => x.ClientConfigurationName).Returns("name");
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(new Mock<ILdapServerConfiguration>().Object);
         contextMock.SetupProperty(x => x.UserLdapProfile);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         var context = contextMock.Object;
         var cacheMock = new Mock<ICacheService>();
         var step = new ProfileLoadingStep(loaderMock.Object, cacheMock.Object, NullLogger<ProfileLoadingStep>.Instance);
         await step.ExecuteAsync(context);
 
         Assert.Null(context.UserLdapProfile);
+    }
+    
+    [Fact]
+    public async Task ExecStep_NotDomainAccount_ShouldSkipStep()
+    {
+        //Arrange
+        var loaderMock = new Mock<ILdapProfileService>();
+        loaderMock
+            .Setup(x => x.FindUserProfile(It.IsAny<FindUserProfileRequest>()))
+            .Returns(() => null);
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("user@example.com");
+        contextMock.Setup(x => x.RadiusReplyAttributes).Returns(new Dictionary<string, RadiusReplyAttributeValue[]>());
+        contextMock.Setup(x => x.LdapSchema).Returns(new Mock<ILdapSchema>().Object);
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("name");
+        contextMock.Setup(x => x.LdapServerConfiguration).Returns(new Mock<ILdapServerConfiguration>().Object);
+        contextMock.SetupProperty(x => x.UserLdapProfile);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(false);
+        
+        var context = contextMock.Object;
+        var cacheMock = new Mock<ICacheService>();
+        var step = new ProfileLoadingStep(loaderMock.Object, cacheMock.Object, NullLogger<ProfileLoadingStep>.Instance);
+        
+        //Act
+        await step.ExecuteAsync(context);
+
+        //Assert
+        Assert.Null(context.UserLdapProfile);
+        loaderMock.Verify(x => x.FindUserProfile(It.IsAny<FindUserProfileRequest>()), Times.Never);
     }
 
     private class LdapProfileMock : ILdapProfile

--- a/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/SecondFactorStepTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/SecondFactorStepTests.cs
@@ -148,6 +148,7 @@ public class SecondFactorStepTests
         contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("1","2"));
         contextMock.SetupProperty(x => x.ResponseInformation);
+        contextMock.Setup(x=> x.IsDomainAccount).Returns(true);
         
         var ldapConfig = new Mock<ILdapServerConfiguration>();
         ldapConfig.Setup(x => x.SecondFaGroups).Returns(new List<string>());
@@ -191,6 +192,7 @@ public class SecondFactorStepTests
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("userName");
         contextMock.Setup(x => x.LdapSchema).Returns(new Mock<ILdapSchema>().Object);
         contextMock.SetupProperty(x => x.AuthenticationState);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         
         var context = contextMock.Object;
         context.AuthenticationState = new AuthenticationState();
@@ -227,6 +229,7 @@ public class SecondFactorStepTests
         contextMock.Setup(x => x.LdapSchema).Returns(new Mock<ILdapSchema>().Object);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("userName");
         contextMock.SetupProperty(x => x.AuthenticationState);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         
         var context = contextMock.Object;
         context.AuthenticationState = new AuthenticationState();
@@ -235,5 +238,57 @@ public class SecondFactorStepTests
         await step.ExecuteAsync(context);
         
         Assert.Equal(AuthenticationStatus.Bypass, context.AuthenticationState.SecondFactorStatus);
+    }
+    
+    [Fact]
+    public async Task ExecuteAsync_NoDomainAccount_ShouldSkipGroupCheck()
+    {
+        //Arrange
+        var apiServiceMock = new Mock<IMultifactorApiService>();
+        apiServiceMock.Setup(x => x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>())).ReturnsAsync(new MultifactorResponse(AuthenticationStatus.Awaiting, "state", "message"));
+        
+        var challengeProviderMock = new Mock<IChallengeProcessorProvider>();
+        challengeProviderMock.Setup(x => x.GetChallengeProcessorByType(ChallengeType.SecondFactor)).Returns(new Mock<IChallengeProcessor>().Object);
+        
+        var groupServiceMock = new Mock<ILdapGroupService>();
+        
+        var step = new SecondFactorStep(apiServiceMock.Object, challengeProviderMock.Object, groupServiceMock.Object, NullLogger<SecondFactorStep>.Instance);
+
+        var packetMock = new Mock<IRadiusPacket>();
+        packetMock.Setup(x => x.IsVendorAclRequest).Returns(false);
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        contextMock.SetupProperty(x => x.AuthenticationState);
+        contextMock.Setup(x => x.RequestPacket).Returns(packetMock.Object);
+        contextMock.Setup(x => x.FirstFactorAuthenticationSource).Returns(AuthenticationSource.Radius);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:1"));
+        contextMock.SetupProperty(x => x.ResponseInformation);
+        contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("1","2"));
+        contextMock.Setup(x=> x.IsDomainAccount).Returns(false);
+        
+        var ldapConfig = new Mock<ILdapServerConfiguration>();
+        ldapConfig.Setup(x => x.SecondFaGroups).Returns(new List<string>() { "group" });
+        ldapConfig.Setup(x => x.SecondFaBypassGroups).Returns(new List<string>() { "group" });
+        contextMock.Setup(x => x.LdapServerConfiguration).Returns(ldapConfig.Object); 
+        
+        var context = contextMock.Object;
+        context.AuthenticationState = new AuthenticationState();
+        context.ResponseInformation = new ResponseInformation();
+        
+        //Act
+        await step.ExecuteAsync(context);
+        
+        //Assert
+        Assert.Equal("state", context.ResponseInformation.State);
+        Assert.Equal("message", context.ResponseInformation.ReplyMessage);
+        groupServiceMock.Verify(x=> x.IsMemberOf(It.IsAny<MembershipRequest>()), Times.Never);
+        apiServiceMock.Verify(x=> x.CreateSecondFactorRequestAsync(It.IsAny<CreateSecondFactorRequest>()), Times.Once);
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/UserGroupLoadingStepTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/UserGroupLoadingStepTests.cs
@@ -6,6 +6,7 @@ using Multifactor.Core.Ldap.Name;
 using Multifactor.Core.Ldap.Schema;
 using Multifactor.Radius.Adapter.v2.Core.Configuration.Client;
 using Multifactor.Radius.Adapter.v2.Core.Ldap;
+using Multifactor.Radius.Adapter.v2.Core.Radius.Packet;
 using Multifactor.Radius.Adapter.v2.Infrastructure.Pipeline.Context;
 using Multifactor.Radius.Adapter.v2.Infrastructure.Pipeline.Steps;
 using Multifactor.Radius.Adapter.v2.Services.Ldap;
@@ -52,6 +53,32 @@ public class UserGroupLoadingStepTests
         await step.ExecuteAsync(context);
         
         Assert.Empty(context.UserGroups);
+        groupService.Verify(x=> x.LoadUserGroups(It.IsAny<LoadUserGroupsRequest>()), Times.Never);
+    }
+    
+    [Fact]
+    public async Task LoadGroups_NoDomainUser_ShouldSkipGroupLoad()
+    {
+        var groupService = new Mock<ILdapGroupService>();
+        var connectionFactory = new Mock<ILdapConnectionFactory>();
+
+        var step = new UserGroupLoadingStep(groupService.Object, connectionFactory.Object, NullLogger<UserGroupLoadingStep>.Instance);
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+        var attributes = new Dictionary<string, RadiusReplyAttributeValue[]>();
+        attributes.Add("key", [new RadiusReplyAttributeValue("memberOf")]);
+        contextMock.Setup(x => x.RadiusReplyAttributes).Returns(attributes);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(false);
+        contextMock.Setup(x=> x.RequestPacket.UserName).Returns("user");
+        contextMock.Setup(x=> x.RequestPacket.AccountType).Returns(AccountType.Local);
+        
+        contextMock.SetupProperty(x => x.UserGroups);
+        var context = contextMock.Object;
+        context.UserGroups = new();
+        
+        await step.ExecuteAsync(context);
+        
+        Assert.Empty(context.UserGroups);
+        groupService.Verify(x=> x.LoadUserGroups(It.IsAny<LoadUserGroupsRequest>()), Times.Never);
     }
     
     [Theory]
@@ -73,6 +100,7 @@ public class UserGroupLoadingStepTests
         contextMock.Setup(x => x.UserLdapProfile.MemberOf).Returns(memberOf);
         contextMock.SetupProperty(x => x.UserGroups);
         contextMock.Setup(x => x.LdapServerConfiguration.LoadNestedGroups).Returns(false);
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         
         var context = contextMock.Object;
         context.UserGroups = new();
@@ -114,6 +142,7 @@ public class UserGroupLoadingStepTests
         contextMock.Setup(x => x.UserLdapProfile.Dn).Returns(new DistinguishedName("dc=group1, dc=domain"));
         contextMock.Setup(x => x.LdapServerConfiguration.ConnectionString).Returns("Server=localhost;Port=5432");
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("userName");
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         
         var context = contextMock.Object;
         context.UserGroups = new();
@@ -154,6 +183,7 @@ public class UserGroupLoadingStepTests
         contextMock.Setup(x => x.UserLdapProfile.Dn).Returns(new DistinguishedName("dc=group1, dc=domain"));
         contextMock.Setup(x => x.LdapServerConfiguration.ConnectionString).Returns("Server=localhost;Port=5432");
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("userName");
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         
         var context = contextMock.Object;
         context.UserGroups = new();
@@ -194,6 +224,7 @@ public class UserGroupLoadingStepTests
         contextMock.Setup(x => x.UserLdapProfile.Dn).Returns(new DistinguishedName("dc=group1, dc=domain"));
         contextMock.Setup(x => x.LdapServerConfiguration.ConnectionString).Returns("Server=localhost;Port=5432");
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("userName");
+        contextMock.Setup(x => x.IsDomainAccount).Returns(true);
         
         var context = contextMock.Object;
         context.UserGroups = new();

--- a/src/Multifactor.Radius.Adapter.v2/Core/Radius/Packet/AccountType.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Radius/Packet/AccountType.cs
@@ -1,0 +1,9 @@
+namespace Multifactor.Radius.Adapter.v2.Core.Radius.Packet;
+
+public enum AccountType
+{
+    Unknown = 0,
+    Domain = 1,
+    Local = 2,
+    Microsoft = 3
+}

--- a/src/Multifactor.Radius.Adapter.v2/Core/Radius/Packet/IRadiusPacket.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Radius/Packet/IRadiusPacket.cs
@@ -4,28 +4,29 @@ namespace Multifactor.Radius.Adapter.v2.Core.Radius.Packet;
 
 public interface IRadiusPacket
 {
-    public PacketCode Code { get; }
-    public byte Identifier { get; }
-    public RadiusAuthenticator Authenticator { get; }
-    public RadiusAuthenticator? RequestAuthenticator { get; }
-    public AuthenticationType AuthenticationType { get; }
-    public string? UserName { get; }
-    public bool IsEapMessageChallenge { get; }
-    public bool IsVendorAclRequest { get; }
-    public bool IsWinLogon { get; }
-    public bool IsOpenVpnStaticChallenge { get; }
-    public string? MsClientMachineAccountNameAttribute { get; }
-    public string? MsRasClientNameAttribute { get; }
-    public string? CallingStationIdAttribute { get; }
-    public string? RemoteHostName { get; }
-    public string? CalledStationIdAttribute { get; }
-    public string? NasIdentifierAttribute { get; }
-    public string? State { get; }
-    public string? TryGetUserPassword();
-    public string? TryGetChallenge();
-    public IReadOnlyDictionary<string, RadiusAttribute> Attributes { get; }
-    public T GetAttribute<T>(string name);
-    public List<T> GetAttributes<T>(string name);
-    public string? GetAttributeValueAsString(string name);
-    public string CreateUniqueKey(IPEndPoint remoteEndpoint);
+    PacketCode Code { get; }
+    byte Identifier { get; }
+    RadiusAuthenticator Authenticator { get; }
+    RadiusAuthenticator? RequestAuthenticator { get; }
+    AuthenticationType AuthenticationType { get; }
+    string? UserName { get; }
+    bool IsEapMessageChallenge { get; }
+    bool IsVendorAclRequest { get; }
+    bool IsWinLogon { get; }
+    bool IsOpenVpnStaticChallenge { get; }
+    string? MsClientMachineAccountNameAttribute { get; }
+    string? MsRasClientNameAttribute { get; }
+    string? CallingStationIdAttribute { get; }
+    string? RemoteHostName { get; }
+    string? CalledStationIdAttribute { get; }
+    string? NasIdentifierAttribute { get; }
+    string? State { get; }
+    string? TryGetUserPassword();
+    string? TryGetChallenge();
+    IReadOnlyDictionary<string, RadiusAttribute> Attributes { get; }
+    T GetAttribute<T>(string name);
+    List<T> GetAttributes<T>(string name);
+    string? GetAttributeValueAsString(string name);
+    string CreateUniqueKey(IPEndPoint remoteEndpoint);
+    AccountType AccountType { get; }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Core/Radius/Packet/RadiusPacket.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Radius/Packet/RadiusPacket.cs
@@ -22,6 +22,15 @@ public class RadiusPacket : IRadiusPacket
     public IReadOnlyDictionary<string, RadiusAttribute> Attributes => _attributes;
 
     public string? UserName => GetAttributeValueAsString("User-Name");
+    
+    public AccountType AccountType
+    {
+        get
+        {
+            var attrValue = AcctAuthentic ?? 0;
+            return UintToAccountType(attrValue);
+        }
+    }
 
     public AuthenticationType AuthenticationType
     {
@@ -218,4 +227,26 @@ public class RadiusPacket : IRadiusPacket
 
         _attributes.Remove(name);
     }
+    
+    private int? AcctAuthentic
+    {
+        get
+        {
+            if (Attributes.TryGetValue("Acct-Authentic", out var attribute))
+            {
+                var attrVal = attribute.Values.FirstOrDefault() as int?;
+                return attrVal;
+            }
+
+            return null;
+        }
+    }
+
+    private static AccountType UintToAccountType(int value) => value switch
+    {
+        1 => AccountType.Domain,
+        2 => AccountType.Local,
+        3 => AccountType.Microsoft,
+        _ => AccountType.Domain
+    };
 }

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Context/IRadiusPipelineExecutionContext.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Context/IRadiusPipelineExecutionContext.cs
@@ -44,4 +44,5 @@ public interface IRadiusPipelineExecutionContext
     string ClientConfigurationName { get; }
     SharedSecret RadiusSharedSecret { get; }
     IReadOnlyList<string> ApiUrls { get; }
+    bool IsDomainAccount { get; }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Context/RadiusPipelineExecutionContext.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Context/RadiusPipelineExecutionContext.cs
@@ -47,6 +47,7 @@ public class RadiusPipelineExecutionContext : IRadiusPipelineExecutionContext
     public string ClientConfigurationName => _settings.ClientConfigurationName;
     public SharedSecret RadiusSharedSecret => _settings.RadiusSharedSecret;
     public IReadOnlyList<string> ApiUrls => _settings.ApiUrls;
+    public bool IsDomainAccount => RequestPacket.AccountType == AccountType.Domain;
 
     public RadiusPipelineExecutionContext(IPipelineExecutionSettings settings, IRadiusPacket requestPacket)
     {

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Steps/AccessGroupsCheckingStep.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Steps/AccessGroupsCheckingStep.cs
@@ -24,28 +24,62 @@ public class AccessGroupsCheckingStep : IRadiusPipelineStep
         _logger.LogDebug("'{name}' started", nameof(AccessGroupsCheckingStep));
         ArgumentNullException.ThrowIfNull(context, nameof(context));
         ArgumentNullException.ThrowIfNull(context.LdapServerConfiguration, nameof(context.LdapServerConfiguration));
-        ArgumentNullException.ThrowIfNull(context.UserLdapProfile, nameof(context.UserLdapProfile));
         ArgumentNullException.ThrowIfNull(context.LdapSchema, nameof(context.LdapSchema));
-        
-        var serverConfig = context.LdapServerConfiguration;
-        if (serverConfig.AccessGroups.Count == 0)
-            return Task.CompletedTask;
 
+        var serverConfig = context.LdapServerConfiguration;
+
+        if (ShouldSkipStep(context))
+            return Task.CompletedTask;
+        
+        ArgumentNullException.ThrowIfNull(context.UserLdapProfile, nameof(context.UserLdapProfile));
+        
         var accessGroupsDns = serverConfig.AccessGroups.Select(x => new DistinguishedName(x)).ToArray();
         var request = GetMembershipRequest(context, accessGroupsDns);
         var isMember = _ldapGroupService.IsMemberOf(request);
-            
+
         return isMember ? Task.CompletedTask : TerminatePipeline(context);
     }
 
-    private MembershipRequest GetMembershipRequest(IRadiusPipelineExecutionContext context, DistinguishedName[] accessGroupNames) => new(context, accessGroupNames);
+    private MembershipRequest GetMembershipRequest(IRadiusPipelineExecutionContext context,
+        DistinguishedName[] accessGroupNames) => new(context, accessGroupNames);
 
     private Task TerminatePipeline(IRadiusPipelineExecutionContext context)
     {
-        _logger.LogWarning("User '{user}' is not member of any access group of the '{connectionString}'.", context.UserLdapProfile.Dn, context.LdapServerConfiguration.ConnectionString);
+        _logger.LogWarning("User '{user}' is not member of any access group of the '{connectionString}'.",
+            context.UserLdapProfile!.Dn, context.LdapServerConfiguration!.ConnectionString);
         context.AuthenticationState.FirstFactorStatus = AuthenticationStatus.Reject;
         context.AuthenticationState.SecondFactorStatus = AuthenticationStatus.Reject;
         context.ExecutionState.Terminate();
         return Task.CompletedTask;
+    }
+
+    private bool ShouldSkipStep(IRadiusPipelineExecutionContext context)
+    {
+        return NoAccessGroups(context) || UnsupportedAccountType(context);
+    }
+    
+    private bool NoAccessGroups(IRadiusPipelineExecutionContext config)
+    {
+        var noGroups = config.LdapServerConfiguration!.AccessGroups.Count == 0;
+        
+        if (!noGroups)
+            return false;
+        
+        _logger.LogDebug("No access groups were specified.");
+        return true;
+    }
+
+    private bool UnsupportedAccountType(IRadiusPipelineExecutionContext context)
+    {
+        if (context.IsDomainAccount)
+            return false;
+        
+        var packet = context.RequestPacket;
+        _logger.LogInformation(
+            "User '{user}' used '{accountType}' account to log in. Access groups checking is skipped.",
+            packet.UserName,
+            packet.AccountType);
+
+        return true;
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Steps/ProfileLoadingStep.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Steps/ProfileLoadingStep.cs
@@ -26,6 +26,9 @@ public class ProfileLoadingStep : IRadiusPipelineStep
     {
         _logger.LogDebug("'{name}' started", nameof(ProfileLoadingStep));
         
+        if (ShouldSkipStep(context))
+            return Task.CompletedTask;
+        
         ArgumentNullException.ThrowIfNull(context.LdapServerConfiguration);
         
         if (string.IsNullOrWhiteSpace(context.RequestPacket.UserName))
@@ -101,5 +104,20 @@ public class ProfileLoadingStep : IRadiusPipelineStep
     private void SaveToCache(string cacheKey, ILdapProfile profile, DateTimeOffset expirationDate)
     {
         _cache.Set(cacheKey, profile, expirationDate);
+    }
+    
+    private bool ShouldSkipStep(IRadiusPipelineExecutionContext context)
+    {
+        if (context.IsDomainAccount)
+            return false;
+        
+        var packet = context.RequestPacket;
+        
+        _logger.LogInformation(
+            "User '{user}' used '{accountType}' account to log in. Profile load is skipped.",
+            packet.UserName,
+            context.RequestPacket.AccountType);
+
+        return true;
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Steps/SecondFactorStep.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Steps/SecondFactorStep.cs
@@ -53,13 +53,15 @@ public class SecondFactorStep : IRadiusPipelineStep
             return false;
         }
 
-        if (ShouldBypassByGroups(context))
-        {
-            _logger.LogInformation("Second factor is bypassed for user {user:l} at '{domain:l}'", context.RequestPacket.UserName, context.LdapServerConfiguration.ConnectionString);
-            return false;
-        }
+        if (UnsupportedAccountType(context))
+            return true;
         
-        return true;
+        if (!ShouldBypassByGroups(context))
+            return true;
+        
+        _logger.LogInformation("Second factor is bypassed for user {user:l} at '{domain:l}'", context.RequestPacket.UserName, context.LdapServerConfiguration.ConnectionString);
+        
+        return false;
     }
 
     private bool ShouldBypassByRequest(IRadiusPipelineExecutionContext context)
@@ -123,5 +125,18 @@ public class SecondFactorStep : IRadiusPipelineStep
         var groupDns = targetGroupsNames.Select(x => new DistinguishedName(x)).ToArray();
         
         return new MembershipRequest(context, groupDns);
+    }
+    
+    private bool UnsupportedAccountType(IRadiusPipelineExecutionContext context)
+    {
+        if (context.IsDomainAccount)
+            return false;
+        
+        _logger.LogInformation(
+            "User '{user}' used '{accountType}' account to log in. Second factor groups check is skipped.",
+            context.RequestPacket.UserName,
+            context.RequestPacket.AccountType);
+
+        return true;
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Steps/UserGroupLoadingStep.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Pipeline/Steps/UserGroupLoadingStep.cs
@@ -29,10 +29,10 @@ public class UserGroupLoadingStep : IRadiusPipelineStep
         _logger.LogDebug("'{name}' started", nameof(UserGroupLoadingStep));
 
         if (ShouldSkipGroupLoading(context))
-        {
-            _logger.LogDebug("User groups are not required.");
             return Task.CompletedTask;
-        }
+        
+        ArgumentNullException.ThrowIfNull(context.UserLdapProfile, nameof(context.UserLdapProfile));
+        ArgumentNullException.ThrowIfNull(context.LdapServerConfiguration, nameof(context.LdapServerConfiguration));
         
         var userGroups = new HashSet<string>();
         context.UserGroups = userGroups;
@@ -53,9 +53,9 @@ public class UserGroupLoadingStep : IRadiusPipelineStep
 
     private void LoadGroupsFromLdapCatalog(IRadiusPipelineExecutionContext context, HashSet<string> userGroups)
     {
-        using var connection = _ldapConnectionFactory.CreateConnection(GetLdapConnectionOptions(context.LdapServerConfiguration));
+        using var connection = _ldapConnectionFactory.CreateConnection(GetLdapConnectionOptions(context.LdapServerConfiguration!));
         
-        if (context.LdapServerConfiguration.NestedGroupsBaseDns.Count > 0)
+        if (context.LdapServerConfiguration!.NestedGroupsBaseDns.Count > 0)
             LoadUserGroupsFromContainers(context, userGroups, connection);
         else
             LoadUserGroupsFromRoot(context, userGroups, connection);
@@ -63,14 +63,14 @@ public class UserGroupLoadingStep : IRadiusPipelineStep
 
     private void LoadUserGroupsFromContainers(IRadiusPipelineExecutionContext context, HashSet<string> userGroups, ILdapConnection connection)
     {
-        foreach (var dn in context.LdapServerConfiguration.NestedGroupsBaseDns)
+        foreach (var dn in context.LdapServerConfiguration!.NestedGroupsBaseDns)
         {
             _logger.LogDebug("Loading nested groups from '{dn}' at '{domain}' for '{user}'", dn, context.LdapServerConfiguration.ConnectionString, context.RequestPacket.UserName);
             
             var request = new LoadUserGroupsRequest(
                 context.LdapSchema!,
                 connection,
-                context.UserLdapProfile.Dn,
+                context.UserLdapProfile!.Dn,
                 new DistinguishedName(dn));
             
             var groups = _ldapGroupService.LoadUserGroups(request);
@@ -87,9 +87,9 @@ public class UserGroupLoadingStep : IRadiusPipelineStep
         var request = new LoadUserGroupsRequest(
             context.LdapSchema!,
             connection,
-            context.UserLdapProfile.Dn);
+            context.UserLdapProfile!.Dn);
             
-        _logger.LogDebug("Loading nested groups from root at '{domain}' for '{user}'", context.LdapServerConfiguration.ConnectionString, context.RequestPacket.UserName);   
+        _logger.LogDebug("Loading nested groups from root at '{domain}' for '{user}'", context.LdapServerConfiguration!.ConnectionString, context.RequestPacket.UserName);   
         var groups = _ldapGroupService.LoadUserGroups(request);
             
         var groupLog = string.Join("\n", groups);
@@ -97,12 +97,6 @@ public class UserGroupLoadingStep : IRadiusPipelineStep
         foreach (var group in groups)
             userGroups.Add(group);
     }
-
-    private bool ShouldSkipGroupLoading(IRadiusPipelineExecutionContext context) => !context
-        .RadiusReplyAttributes
-        .Values
-        .SelectMany(x => x)
-        .Any(x => x.IsMemberOf || x.UserGroupCondition.Count > 0);
 
     private LdapConnectionOptions GetLdapConnectionOptions(ILdapServerConfiguration serverConfiguration)
     {
@@ -112,5 +106,38 @@ public class UserGroupLoadingStep : IRadiusPipelineStep
             serverConfiguration.UserName,
             serverConfiguration.Password,
             TimeSpan.FromSeconds(serverConfiguration.BindTimeoutInSeconds));
+    }
+
+    private bool ShouldSkipGroupLoading(IRadiusPipelineExecutionContext context)
+    {
+        return GroupsNotRequired(context) || UnsupportedAccountType(context);
+    }
+
+    private bool GroupsNotRequired(IRadiusPipelineExecutionContext context)
+    {
+        var notRequired = !context
+            .RadiusReplyAttributes
+            .Values
+            .SelectMany(x => x)
+            .Any(x => x.IsMemberOf || x.UserGroupCondition.Count > 0);
+
+        if (!notRequired)
+            return false;
+        
+        _logger.LogDebug("User groups are not required.");
+        return true;
+    }
+
+    private bool UnsupportedAccountType(IRadiusPipelineExecutionContext context)
+    {
+        if (context.IsDomainAccount)
+            return false;
+        
+        _logger.LogInformation(
+            "User '{user}' used '{accountType}' account to log in. User group loading is skipped.",
+            context.RequestPacket.UserName,
+            context.RequestPacket.AccountType);
+        
+        return true;
     }
 }


### PR DESCRIPTION
Добавлена обработка атрибута Acct-Authentic для работы с winlogon.

1. RadiusPacket - добавил свойство AccountType 
2. RadiusPipelineExecutionContext - добавил IsDomainAccount  для простоты использования
3. AccessGroupsCheckingStep - добавил ShouldSkipStep, если не Domain аккаунт, то пропускаем проверку
4. ProfileLoadingStep - добавил ShouldSkipStep, если не Domain аккаунт, то пропускаем загрузку профиля
5. SecondFactorStep - добавил UnsupportedAccountType, если не Domain аккаунт, то проверка групп не осуществляется
6. UserGroupLoadingStep - добавил ShouldSkipGroupLoading,  если не Domain аккаунт, то выгрузка групп не происходит
7. Добавил тестов на тип аккаунта