### PR TITLE
DEV-909 removed authentication-cache-minimal-matching

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.Tests/AccessChallengeTests/SecondFactorChallengeProcessorTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/AccessChallengeTests/SecondFactorChallengeProcessorTests.cs
@@ -193,7 +193,7 @@ public class SecondFactorChallengeProcessorTests
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("1", "2"));
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(new Mock<ILdapServerConfiguration>().Object);
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         var context = contextMock.Object;
         
         context.ResponseInformation.State = "2";
@@ -229,7 +229,7 @@ public class SecondFactorChallengeProcessorTests
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("1", "2"));
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(new Mock<ILdapServerConfiguration>().Object);
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         var context = contextMock.Object;
         
         context.ResponseInformation.State = "2";
@@ -267,7 +267,7 @@ public class SecondFactorChallengeProcessorTests
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("1", "2"));
         contextMock.Setup(x => x.LdapServerConfiguration).Returns(new Mock<ILdapServerConfiguration>().Object);
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         var context = contextMock.Object;
         
         context.ResponseInformation.State = "2";

--- a/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ClientConfigurationFactoryTests/AppSettingsTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/ClientConfigurationFactoryTests/AppSettingsTests.cs
@@ -33,7 +33,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -98,7 +97,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -169,7 +167,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -221,7 +218,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -273,7 +269,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -324,7 +319,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -375,7 +369,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -421,7 +414,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -483,7 +475,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             }
@@ -517,7 +508,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             },
@@ -554,7 +544,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             }
@@ -590,7 +579,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             }
@@ -624,7 +612,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             }
@@ -658,7 +645,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             }
@@ -692,7 +678,6 @@ public class AppSettingsTests
                 PrivacyMode = "Full",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             }
@@ -727,7 +712,6 @@ public class AppSettingsTests
                 PrivacyMode = privacyMode,
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "3"
             }
@@ -764,7 +748,6 @@ public class AppSettingsTests
                 PrivacyMode = "None",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = delay
             }
@@ -800,7 +783,6 @@ public class AppSettingsTests
                 PrivacyMode = "None",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = "00:01:00",
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "1"
             }
@@ -839,7 +821,6 @@ public class AppSettingsTests
                 PrivacyMode = "None",
                 PreAuthenticationMethod = "None",
                 AuthenticationCacheLifetime = lifetime,
-                AuthenticationCacheMinimalMatching = true,
                 CallingStationIdAttribute = "12345",
                 InvalidCredentialDelay = "1"
             }

--- a/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/LoadXmlConfigurationTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/ConfigurationTests/LoadXmlConfigurationTests.cs
@@ -81,7 +81,6 @@ public class LoadXmlConfigurationTests
         Assert.Equal("privacy-mode", config.AppSettings.PrivacyMode);
         Assert.Equal("pre-authentication-method", config.AppSettings.PreAuthenticationMethod);
         Assert.Equal("authentication-cache-lifetime", config.AppSettings.AuthenticationCacheLifetime);
-        Assert.True(config.AppSettings.AuthenticationCacheMinimalMatching);
         Assert.Equal("invalid-credential-delay", config.AppSettings.InvalidCredentialDelay);
         Assert.Equal("calling-station-id-attribute", config.AppSettings.CallingStationIdAttribute);
         Assert.Equal("multifactor-api-url", config.AppSettings.MultifactorApiUrl);

--- a/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/SecondFactorStepTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/PipelineTests/StepsTests/SecondFactorStepTests.cs
@@ -93,7 +93,7 @@ public class SecondFactorStepTests
         contextMock.SetupProperty(x => x.ResponseInformation);
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -141,7 +141,7 @@ public class SecondFactorStepTests
         contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:1"));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
-        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);

--- a/src/Multifactor.Radius.Adapter.v2.Tests/Unit/MultifactorApi/MultifactorApiServiceTests.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Tests/Unit/MultifactorApi/MultifactorApiServiceTests.cs
@@ -44,7 +44,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.RequestPacket.UserName).Returns(identity);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
@@ -87,7 +87,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -126,7 +126,40 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Attributes).Returns([]);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
+        contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
+        contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
+        contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
+        contextMock.Setup(x => x.UserNameTransformRules).Returns(new UserNameTransformRules());
+        contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
+
+        var context = contextMock.Object;
+        var response = await service.CreateSecondFactorRequestAsync(new CreateSecondFactorRequest(context));
+        Assert.NotNull(response);
+        Assert.Equal(AuthenticationStatus.Bypass, response.Code);
+    }
+    
+    [Fact]
+    public async Task CreateSecondFactorRequestAsync_NoCallingStationIdAttributeAndBypassByCache_ShouldReturnBypass()
+    {
+        var apiMock = new Mock<IMultifactorApi>();
+        var cacheMock = new Mock<IAuthenticatedClientCache>();
+        cacheMock.Setup(x => x.TryHitCache(It.Is<string?>(id => id == "127.0.0.1"), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthenticatedClientCacheConfig>())).Returns(true);
+        var service =
+            new MultifactorApiService(apiMock.Object, cacheMock.Object, NullLogger<MultifactorApiService>.Instance);
+
+        var contextMock = new Mock<IRadiusPipelineExecutionContext>();
+
+        contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(true);
+        contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
+        contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
+        contextMock.Setup(x => x.RemoteEndpoint).Returns(IPEndPoint.Parse("127.0.0.1:8080"));
+        contextMock.Setup(x => x.UserLdapProfile.DisplayName).Returns("123");
+        contextMock.Setup(x => x.UserLdapProfile.Email).Returns("email");
+        contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
+        contextMock.Setup(x => x.UserLdapProfile.Attributes).Returns([]);
+        contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
+        contextMock.Setup(x => x.AuthenticationCacheLifetime).Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -177,7 +210,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
 
@@ -209,7 +242,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
@@ -253,7 +286,7 @@ public class MultifactorApiServiceTests
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
         contextMock.Setup(x => x.RequestPacket.UserName).Returns("username");
@@ -312,7 +345,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.ApiUrls).Returns(["url"]);
         var context = contextMock.Object;
@@ -365,7 +398,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(bypass);
@@ -425,7 +458,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(false);
@@ -485,7 +518,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.ApiUrls).Returns([brokenUrl, mfUrl]);
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(false);
@@ -547,7 +580,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123456", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.ClientConfigurationName).Returns("configName");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("123", "123"));
         contextMock.Setup(x => x.ApiUrls).Returns([mfUrl, brokenUrl]);
         contextMock.Setup(x => x.BypassSecondFactorWhenApiUnreachable).Returns(bypass);
@@ -613,7 +646,7 @@ public class MultifactorApiServiceTests
 
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.ApiCredential).Returns(new ApiCredential("key", "secret"));
@@ -647,7 +680,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -690,7 +723,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -721,7 +754,7 @@ public class MultifactorApiServiceTests
 
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
@@ -751,7 +784,7 @@ public class MultifactorApiServiceTests
 
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
@@ -781,7 +814,7 @@ public class MultifactorApiServiceTests
 
         var contextMock = new Mock<IRadiusPipelineExecutionContext>();
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.UserLdapProfile).Returns(new Mock<ILdapProfile>().Object);
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.LdapServerConfiguration.IdentityAttribute).Returns(string.Empty);
@@ -831,7 +864,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -882,7 +915,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -935,7 +968,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);
@@ -995,7 +1028,7 @@ public class MultifactorApiServiceTests
         contextMock.Setup(x => x.UserLdapProfile.Phone).Returns("phone");
         contextMock.Setup(x => x.ClientConfigurationName).Returns("config");
         contextMock.Setup(x => x.AuthenticationCacheLifetime)
-            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08", false));
+            .Returns(AuthenticatedClientCacheConfig.Create("08:08:08"));
         contextMock.Setup(x => x.PrivacyMode).Returns(PrivacyModeDescriptor.Default);
         contextMock.Setup(x => x.Passphrase).Returns(UserPassphrase.Parse("123", PreAuthModeDescriptor.Default));
         contextMock.Setup(x => x.PreAuthnMode).Returns(PreAuthModeDescriptor.Default);

--- a/src/Multifactor.Radius.Adapter.v2/Core/Auth/AuthenticatedClientCacheConfig.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Auth/AuthenticatedClientCacheConfig.cs
@@ -3,24 +3,22 @@
 public record AuthenticatedClientCacheConfig
 {
     public TimeSpan Lifetime { get; }
-    public bool MinimalMatching { get; }
     public bool Enabled => Lifetime != TimeSpan.Zero;
 
-    public static AuthenticatedClientCacheConfig Default => new(TimeSpan.Zero, false);
+    public static AuthenticatedClientCacheConfig Default => new(TimeSpan.Zero);
 
-    public AuthenticatedClientCacheConfig(TimeSpan lifetime, bool minimalMatching)
+    public AuthenticatedClientCacheConfig(TimeSpan lifetime)
     {
         Lifetime = lifetime;
-        MinimalMatching = minimalMatching;
     }
 
-    public static AuthenticatedClientCacheConfig Create(string value, bool minimalMatching)
+    public static AuthenticatedClientCacheConfig Create(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
             return Default;
         }
 
-        return new AuthenticatedClientCacheConfig(TimeSpan.ParseExact(value, @"hh\:mm\:ss", null, System.Globalization.TimeSpanStyles.None), minimalMatching);
+        return new AuthenticatedClientCacheConfig(TimeSpan.ParseExact(value, @"hh\:mm\:ss", null, System.Globalization.TimeSpanStyles.None));
     }
 }

--- a/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Client/Build/ClientConfigurationFactory.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Core/Configuration/Client/Build/ClientConfigurationFactory.cs
@@ -274,9 +274,7 @@ public class ClientConfigurationFactory : IClientConfigurationFactory
     {
         try
         {
-            var ltConf = AuthenticatedClientCacheConfig.Create(
-                appSettings.AuthenticationCacheLifetime,
-                appSettings.AuthenticationCacheMinimalMatching);
+            var ltConf = AuthenticatedClientCacheConfig.Create(appSettings.AuthenticationCacheLifetime);
             builder.SetAuthenticationCacheLifetime(ltConf);
         }
         catch

--- a/src/Multifactor.Radius.Adapter.v2/Infrastructure/Configuration/RadiusAdapter/Sections/AppSettingsSection.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Infrastructure/Configuration/RadiusAdapter/Sections/AppSettingsSection.cs
@@ -58,9 +58,6 @@ public class AppSettingsSection
     [Description("authentication-cache-lifetime")]
     public string AuthenticationCacheLifetime { get; init; } = string.Empty;
 
-    [Description("authentication-cache-minimal-matching")]
-    public bool AuthenticationCacheMinimalMatching { get; init; } = false;
-
     [Description("invalid-credential-delay")]
     public string InvalidCredentialDelay { get; init; } = string.Empty;
 

--- a/src/Multifactor.Radius.Adapter.v2/Services/AuthenticatedClientCache/AuthenticatedClientCache.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/AuthenticatedClientCache/AuthenticatedClientCache.cs
@@ -24,9 +24,9 @@ namespace Multifactor.Radius.Adapter.v2.Services.AuthenticatedClientCache;
             if (!cacheConfig.Enabled)
                 return false;
 
-            if (!cacheConfig.MinimalMatching && string.IsNullOrWhiteSpace(callingStationId))
+            if (string.IsNullOrWhiteSpace(callingStationId))
             {
-                _logger.LogWarning("Remote host parameter miss for user {userName:l}", userName);
+                _logger.LogError("Remote host parameter miss for user {userName:l}", userName);
                 return false;
             }
 
@@ -49,7 +49,7 @@ namespace Multifactor.Radius.Adapter.v2.Services.AuthenticatedClientCache;
             ArgumentNullException.ThrowIfNull(cacheConfig);
             ArgumentException.ThrowIfNullOrWhiteSpace(clientName);
             
-            if (!cacheConfig.Enabled || !cacheConfig.MinimalMatching && string.IsNullOrWhiteSpace(callingStationId))
+            if (!cacheConfig.Enabled || string.IsNullOrWhiteSpace(callingStationId))
                 return;
 
             var client = AuthenticatedClient.Create(callingStationId, clientName, userName);

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApiService.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApiService.cs
@@ -47,7 +47,7 @@ public class MultifactorApiService : IMultifactorApiService
             _logger.LogInformation(
                 "Bypass second factor for user '{user:l}' with calling-station-id {csi:l} from {host:l}:{port}",
                 personalData.Identity,
-                personalData.CalledStationId,
+                personalData.CallingStationId,
                 request.RemoteEndpoint.Address,
                 request.RemoteEndpoint.Port);
             return new MultifactorResponse(AuthenticationStatus.Bypass);

--- a/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApiService.cs
+++ b/src/Multifactor.Radius.Adapter.v2/Services/MultifactorApi/MultifactorApiService.cs
@@ -40,15 +40,14 @@ public class MultifactorApiService : IMultifactorApiService
         }
 
         var personalData = GetPersonalData(request);
-        var callingStationId = request.RequestPacket.CallingStationIdAttribute;
 
         //try to get authenticated client to bypass second factor if configured
-        if (_authenticatedClientCache.TryHitCache(callingStationId, personalData.Identity, request.ConfigName, request.AuthenticationCacheLifetime))
+        if (_authenticatedClientCache.TryHitCache(personalData.CallingStationId, personalData.Identity, request.ConfigName, request.AuthenticationCacheLifetime))
         {
             _logger.LogInformation(
                 "Bypass second factor for user '{user:l}' with calling-station-id {csi:l} from {host:l}:{port}",
                 personalData.Identity,
-                callingStationId,
+                personalData.CalledStationId,
                 request.RemoteEndpoint.Address,
                 request.RemoteEndpoint.Port);
             return new MultifactorResponse(AuthenticationStatus.Bypass);
@@ -81,8 +80,8 @@ public class MultifactorApiService : IMultifactorApiService
 
                 if (responseCode == AuthenticationStatus.Accept && !(response?.Bypassed ?? false))
                 {
-                    LogGrantedInfo(personalData.Identity, response, request.RequestPacket.CallingStationIdAttribute);
-                    _authenticatedClientCache.SetCache(callingStationId, personalData.Identity, request.ConfigName, request.AuthenticationCacheLifetime);
+                    LogGrantedInfo(personalData.Identity, response, personalData.CalledStationId);
+                    _authenticatedClientCache.SetCache(personalData.CallingStationId, personalData.Identity, request.ConfigName, request.AuthenticationCacheLifetime);
                 }
 
                 return new MultifactorResponse(responseCode, response?.Id, response?.ReplyMessage);
@@ -122,7 +121,10 @@ public class MultifactorApiService : IMultifactorApiService
             RequestId = request.RequestId
         };
 
+        var callingStationIdAttr = request.RequestPacket.CallingStationIdAttribute;
+        var callingStationId = GetCallingStationId(callingStationIdAttr, request.RemoteEndpoint);
         MultifactorResponse cloudResponse = new MultifactorResponse(AuthenticationStatus.Reject);
+        
         foreach (var apiUrl in request.ApiUrls)
         {
             // TODO move to method
@@ -134,8 +136,8 @@ public class MultifactorApiService : IMultifactorApiService
                 if (responseCode != AuthenticationStatus.Accept || response.Bypassed)
                     return new MultifactorResponse(responseCode, response?.ReplyMessage);
                 
-                LogGrantedInfo(identity, response, request.RequestPacket.CallingStationIdAttribute);
-                _authenticatedClientCache.SetCache(request.RequestPacket.CallingStationIdAttribute, identity, request.ConfigName, request.AuthenticationCacheLifetime);
+                LogGrantedInfo(identity, response, callingStationId);
+                _authenticatedClientCache.SetCache(callingStationId, identity, request.ConfigName, request.AuthenticationCacheLifetime);
 
                 return new MultifactorResponse(responseCode, response?.ReplyMessage);
             }
@@ -271,10 +273,8 @@ public class MultifactorApiService : IMultifactorApiService
     {
         var secondFactorIdentity = GetSecondFactorIdentity(request);
         var callingStationId = request.RequestPacket.CallingStationIdAttribute;
-        // CallingStationId may contain hostname. For IP policy to work correctly in MF cloud we need IP instead of hostname
-        var callingStationIdForApiRequest = IPAddress.TryParse(callingStationId ?? string.Empty, out _)
-            ? callingStationId
-            : request.RemoteEndpoint.Address.ToString();
+
+        var callingStationIdForApiRequest = GetCallingStationId(callingStationId, request.RemoteEndpoint);
 
         var phone = request.UserProfile?.Attributes
             .Where(x => request.PhoneAttributesNames.Contains(x.Name.Value))
@@ -292,6 +292,14 @@ public class MultifactorApiService : IMultifactorApiService
         };
 
         return personalData;
+    }
+
+    private string? GetCallingStationId(string? callingStationIdAttributeValue, IPEndPoint remoteEndPoint)
+    {
+        // CallingStationId may contain hostname. For IP policy to work correctly in MF cloud we need IP instead of hostname
+        return IPAddress.TryParse(callingStationIdAttributeValue ?? string.Empty, out _)
+            ? callingStationIdAttributeValue
+            : remoteEndPoint.Address.ToString();
     }
 
     private AccessRequest GetRequestPayload(PersonalData personalData, CreateSecondFactorRequest context)


### PR DESCRIPTION
Убрал настройку authentication-cache-minimal-matching, теперь если нет Calling-Station-Id атрибута, то для кэша используется IP из UDP пакета