### PR TITLE
DEV-927

### DIFF
--- a/src/MultiFactor.Radius.Adapter.Tests/MultifactorApiClientTests.cs
+++ b/src/MultiFactor.Radius.Adapter.Tests/MultifactorApiClientTests.cs
@@ -82,4 +82,42 @@ public class MultifactorApiClientTests
         await Assert.ThrowsAsync<MultifactorApiUnreachableException>(async () =>
             await apiClient.ChallengeAsync(new ChallengeDto(), new BasicAuthHeaderValue("test", "test")));
     }
+    
+    [Fact]
+    public async Task CreateRequest_TaskCanceledException_ShouldReturnReject()
+    {
+        var exception = new TaskCanceledException();
+        var httpClientAdapterMock = new Mock<IHttpClientAdapter>();
+        httpClientAdapterMock
+            .Setup(x => x.PostAsync<MultiFactorApiResponse<AccessRequestDto>>(
+                It.IsAny<string>(),
+                It.IsAny<object>(),
+                It.IsAny<Dictionary<string,string>>()))
+            .Throws(exception);
+        var logger = new Mock<ILogger<MultifactorApiClient>>();
+        var apiClient = new MultifactorApiClient(logger.Object, httpClientAdapterMock.Object);
+        
+        var response = await apiClient.CreateRequestAsync(new CreateRequestDto(), new BasicAuthHeaderValue("test", "test"));
+        
+        Assert.Equal(RequestStatus.Denied, response.Status);
+    }
+    
+    [Fact]
+    public async Task CreateChallenge_TaskCanceledException_ShouldReturnReject()
+    {
+        var exception = new TaskCanceledException();
+        var httpClientAdapterMock = new Mock<IHttpClientAdapter>();
+        httpClientAdapterMock
+            .Setup(x => x.PostAsync<MultiFactorApiResponse<AccessRequestDto>>(
+                It.IsAny<string>(),
+                It.IsAny<object>(),
+                It.IsAny<Dictionary<string,string>>()))
+            .Throws(exception);
+        var logger = new Mock<ILogger<MultifactorApiClient>>();
+        var apiClient = new MultifactorApiClient(logger.Object, httpClientAdapterMock.Object);
+        
+        var response = await apiClient.ChallengeAsync(new ChallengeDto(), new BasicAuthHeaderValue("test", "test"));
+        
+        Assert.Equal(RequestStatus.Denied, response.Status);
+    }
 }

--- a/src/MultiFactor.Radius.Adapter/Services/MultiFactorApi/MultiFactorApiClient.cs
+++ b/src/MultiFactor.Radius.Adapter/Services/MultiFactorApi/MultiFactorApiClient.cs
@@ -92,9 +92,11 @@ namespace MultiFactor.Radius.Adapter.Services.MultiFactorApi
                     ReplyMessage = "Too Many Requests"
                 };
             }
-            catch (TaskCanceledException tce)
+            catch (TaskCanceledException)
             {
-                throw new MultifactorApiUnreachableException($"Multifactor API host unreachable: {url}. Reason: Http request timeout", tce);
+                var message = "Multifactor API timeout expired.";
+                _logger.LogWarning(message);
+                return new AccessRequestDto() {  Status = RequestStatus.Denied, ReplyMessage = message };
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Release 24.09.2025 | AccessReject when API timeout
#### Fixed
-   If the `multifactor-api-timeout` expires, the warning `Multifactor API timeout expired` will be written and `AccessReject` will be returned.