### PR TITLE
DEV-1151 replace exception with warning log when username is missing …

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/UserNameValidation/UserNameValidationStep.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/UserNameValidation/UserNameValidationStep.cs
@@ -22,7 +22,13 @@ internal sealed class UserNameValidationStep : IRadiusPipelineStep
         var userName = context.RequestPacket.UserName;
         if (string.IsNullOrWhiteSpace(userName))
         {
-            _logger.LogDebug("User name is empty");
+            var clientAddress = context.RequestPacket.ProxyEndpoint?.Address.ToString()
+                                ?? context.RequestPacket.RemoteEndpoint?.Address.ToString();
+            TerminateWithError(context, "Username is required.");
+            _logger.LogWarning(
+                "Can't find User-Name in message id={PacketId} from {Client}",
+                context.RequestPacket.Identifier,
+                clientAddress);
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Когда RADIUS AccessRequest поступает без атрибута User-Name, конвейер продолжает выполнение после шага UserNameValidationStep и завершается с ошибкой на шаге ProfileLoadingStep с исключением InvalidOperationException. Это приводит к появлению множества записей в журнале уровня ERR, и ответ на NAS не отправляется — в результате чего он повторно отправляет пакет, что добавляет еще больше шума в журналы.
