### PR TITLE
DEV-1448 add deny-groups configuration parameter + add DenyGroupsCheckingStep

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.Application/Core/Models/Abstractions/ILdapServerConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Application/Core/Models/Abstractions/ILdapServerConfiguration.cs
@@ -24,4 +24,5 @@ public interface ILdapServerConfiguration
     public IReadOnlyList<string>? IncludedSuffixes { get; }
     public IReadOnlyList<string>? ExcludedSuffixes { get; }
     public IReadOnlyList<DistinguishedName>? BypassSecondFactorWhenApiUnreachableGroups { get; }
+    public IReadOnlyList<DistinguishedName> DenyGroups { get; }
 }

--- a/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/Pipeline/RadiusPipelineFactory.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/Pipeline/RadiusPipelineFactory.cs
@@ -7,6 +7,7 @@ using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.AccessChallenge;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.AccessGroupsCheck;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.AccessRequestFilter;
+using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.DenyGroupsCheck;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.FirstFactor;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.IpWhiteList;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.LoadLdapForest;
@@ -63,6 +64,7 @@ internal sealed class RadiusPipelineFactory : IRadiusPipelineFactory
             steps.Add(CreateStep<LoadLdapSchemaStep>());
             steps.Add(CreateStep<UserNameValidationStep>());
             steps.Add(CreateStep<ProfileLoadingStep>());
+            steps.Add(CreateStep<DenyGroupsCheckingStep>());
             steps.Add(CreateStep<AccessGroupsCheckingStep>());
         }
         

--- a/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/DenyGroupsCheck/DenyGroupsCheckingStep.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/DenyGroupsCheck/DenyGroupsCheckingStep.cs
@@ -1,0 +1,98 @@
+using Microsoft.Extensions.Logging;
+using Multifactor.Radius.Adapter.v2.Application.Core.Enum;
+using Multifactor.Radius.Adapter.v2.Application.Core.Models;
+using Multifactor.Radius.Adapter.v2.Application.Core.Models.Dto;
+using Multifactor.Radius.Adapter.v2.Application.SharedPorts;
+
+namespace Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.DenyGroupsCheck;
+
+public class DenyGroupsCheckingStep : IRadiusPipelineStep
+{
+    private readonly ICheckMembership _checkMembership;
+    private readonly ILogger<DenyGroupsCheckingStep> _logger;
+    private const string StepName = nameof(DenyGroupsCheckingStep);
+ 
+    public DenyGroupsCheckingStep(ICheckMembership checkMembership,
+        ILogger<DenyGroupsCheckingStep> logger)
+    {
+        _checkMembership = checkMembership;
+        _logger = logger;
+    }
+ 
+    public Task ExecuteAsync(RadiusPipelineContext context)
+    {
+        _logger.LogDebug("'{name}' started", StepName);
+        ArgumentNullException.ThrowIfNull(context, nameof(context));
+        ArgumentNullException.ThrowIfNull(context.LdapConfiguration, nameof(context.LdapConfiguration));
+ 
+        if (ShouldSkipStep(context))
+            return Task.CompletedTask;
+ 
+        ArgumentNullException.ThrowIfNull(context.LdapProfile, nameof(context.LdapProfile));
+ 
+        var userIdentity = new UserIdentity(context.RequestPacket.UserName);
+        var domainInfo = context.ForestMetadata?.DetermineForestDomain(userIdentity);
+        var denyGroups = context.LdapConfiguration.DenyGroups;
+ 
+        var isMember = context.LdapProfile.MemberOf.Intersect(denyGroups).Any();
+        if (isMember && !context.LdapConfiguration.LoadNestedGroups)
+        {
+            _logger.LogInformation(
+                "User '{user:l}' is a member of the Deny group in '{domain:l}'. Access rejected.",
+                context.RequestPacket.UserName, context.LdapConfiguration.ConnectionString);
+            return TerminatePipeline(context);
+        }
+ 
+        var request = MembershipDto.FromContext(context, denyGroups, domainInfo);
+        isMember = _checkMembership.Execute(request);
+ 
+        if (isMember)
+        {
+            _logger.LogInformation(
+                "User '{user:l}' is a member of the Deny group in '{domain:l}'. Access rejected.",
+                context.RequestPacket.UserName, context.LdapConfiguration.ConnectionString);
+            return TerminatePipeline(context);
+        }
+ 
+        _logger.LogDebug(
+            "User '{user:l}' is not a member of any Deny group in '{domain:l}'. Access allowed to proceed.",
+            context.RequestPacket.UserName, context.LdapConfiguration.ConnectionString);
+        return Task.CompletedTask;
+    }
+ 
+    private static Task TerminatePipeline(RadiusPipelineContext context)
+    {
+        context.FirstFactorStatus = AuthenticationStatus.Reject;
+        context.SecondFactorStatus = AuthenticationStatus.Reject;
+        context.Terminate();
+        return Task.CompletedTask;
+    }
+ 
+    private bool ShouldSkipStep(RadiusPipelineContext context)
+    {
+        return NoDenyGroups(context) || UnsupportedAccountType(context);
+    }
+ 
+    private bool NoDenyGroups(RadiusPipelineContext context)
+    {
+        var noGroups = context.LdapConfiguration!.DenyGroups.Count == 0;
+        if (!noGroups)
+            return false;
+ 
+        _logger.LogDebug("No deny groups were specified.");
+        return true;
+    }
+ 
+    private bool UnsupportedAccountType(RadiusPipelineContext context)
+    {
+        if (context.IsDomainAccount)
+            return false;
+ 
+        var packet = context.RequestPacket;
+        _logger.LogInformation(
+            "User '{user}' used '{accountType}' account to log in. Deny groups checking is skipped.",
+            packet.UserName,
+            packet.AccountType);
+        return true;
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/DenyGroupsCheck/Module.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/DenyGroupsCheck/Module.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.DenyGroupsCheck;
+
+public static class Module
+{
+    public static IServiceCollection AddDenyGroupsCheck(this IServiceCollection services)
+    {
+        return services.AddTransient<DenyGroupsCheckingStep>();
+    }
+}

--- a/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/Module.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/Module.cs
@@ -3,6 +3,7 @@ using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.SharedSer
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.AccessChallenge;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.AccessGroupsCheck;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.AccessRequestFilter;
+using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.DenyGroupsCheck;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.FirstFactor;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.IpWhiteList;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.LoadLdapForest;
@@ -33,6 +34,7 @@ public static class Module
             .AddFirstFactor()
             .AddAccessRequestFiltering()
             .AddAccessGroupsCheck()
+            .AddDenyGroupsCheck()
             .AddAccessChallenge()
             .AddPreAuthCheck()
             .AddProfileLoading()

--- a/src/Multifactor.Radius.Adapter.v2.Infrastructure/Configurations/Models/AdapterConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Infrastructure/Configurations/Models/AdapterConfiguration.cs
@@ -133,6 +133,8 @@ internal sealed class LdapServerSection
     public string? ExcludedSuffixes { get; set; }
     [Description("bypass-second-factor-when-api-unreachable-groups")]
     public string? BypassSecondFactorWhenApiUnreachableGroups { get; set; }
+    [Description("deny-groups")]
+    public string? DenyGroups { get; set; }
 }
 
 internal sealed class RadiusReplySection

--- a/src/Multifactor.Radius.Adapter.v2.Infrastructure/Configurations/Models/LdapServerConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Infrastructure/Configurations/Models/LdapServerConfiguration.cs
@@ -27,6 +27,7 @@ internal sealed class LdapServerConfiguration : ILdapServerConfiguration
     public IReadOnlyList<string> IncludedSuffixes { get; init; }
     public IReadOnlyList<string> ExcludedSuffixes { get; init; }
     public IReadOnlyList<DistinguishedName> BypassSecondFactorWhenApiUnreachableGroups { get; init; }
+    public IReadOnlyList<DistinguishedName> DenyGroups { get; private init; }
 
     public static LdapServerConfiguration FromConfiguration(LdapServerSection ldapServerSection, string fileName)
     {
@@ -38,6 +39,45 @@ internal sealed class LdapServerConfiguration : ILdapServerConfiguration
 
         if (!string.IsNullOrWhiteSpace(ldapServerSection.IncludedSuffixes) && !string.IsNullOrWhiteSpace(ldapServerSection.ExcludedSuffixes))
             throw new InvalidConfigurationException($"Config name: '{fileName}', LDAP server: '{ldapServerSection.ConnectionString}'. Simultaneous use of 'included-suffixes' and 'excluded-suffixes' is not allowed.");
+        
+        // Validate: deny-groups and access-groups cannot be used together
+        if (!string.IsNullOrWhiteSpace(ldapServerSection.DenyGroups) && !string.IsNullOrWhiteSpace(ldapServerSection.AccessGroups))
+            throw new InvalidConfigurationException(
+                $"Config name: '{fileName}', LDAP server: '{ldapServerSection.ConnectionString}'. " +
+                $"Simultaneous use of 'deny-groups' and 'access-groups' is not allowed.");
+        
+        var parsedDenyGroups = ConfigurationValueParser.TryParseDistinguishedNames(ldapServerSection.DenyGroups, out var denyGroupsParsed)
+            ? denyGroupsParsed
+            : (IReadOnlyList<DistinguishedName>)[];
+ 
+        // Validate: deny-groups cannot intersect with other group parameters
+        if (parsedDenyGroups.Count > 0)
+        {
+            var otherGroups = new[]
+            {
+                (ldapServerSection.SecondFaGroups, "second-fa-groups"),
+                (ldapServerSection.SecondFaBypassGroups, "second-fa-bypass-groups"),
+                (ldapServerSection.AuthenticationCacheGroups, "authentication-cache-groups"),
+                (ldapServerSection.BypassSecondFactorWhenApiUnreachableGroups, "bypass-second-factor-when-api-unreachable-groups")
+            };
+            foreach (var (groupValue, groupName) in otherGroups)
+            {
+                if (string.IsNullOrWhiteSpace(groupValue))
+                    continue;
+                
+                if (!ConfigurationValueParser.TryParseDistinguishedNames(groupValue, out var parsedOther))
+                    continue;
+                
+                var intersection = parsedDenyGroups.Intersect(parsedOther).ToList();
+                if (!intersection.Any())
+                    continue;
+                
+                throw new InvalidConfigurationException(
+                    $"Config name: '{fileName}', LDAP server: '{ldapServerSection.ConnectionString}'. " +
+                    $"Groups specified in 'deny-groups' cannot be listed in '{groupName}': {string.Join(", ", intersection)}");
+            }
+        }
+ 
         var dto = new LdapServerConfiguration
         {
             ConnectionString = !string.IsNullOrWhiteSpace(ldapServerSection.ConnectionString) ? ldapServerSection.ConnectionString :
@@ -108,8 +148,8 @@ internal sealed class LdapServerConfiguration : ILdapServerConfiguration
             BypassSecondFactorWhenApiUnreachableGroups = ConfigurationValueParser.TryParseDistinguishedNames(ldapServerSection.BypassSecondFactorWhenApiUnreachableGroups,
                 out var bypassSecondFactorWhenApiUnreachableGroups)
                 ? bypassSecondFactorWhenApiUnreachableGroups
-                : []
-
+                : [],
+            DenyGroups = parsedDenyGroups
         };
         return dto;
     }


### PR DESCRIPTION
### Что сделано:

Реализован новый параметр конфигурации адаптера `deny-groups`, позволяющий явно запрещать доступ к ресурсам пользователям, входящим в указанные группы AD.

### Пример конфигурации:

`deny-groups="CN=Deny Users,OU=groups,DC=domain,DC=your"`

### Логика работы:

Пользователи из групп deny-groups получают отказ (Reject) на этапе проверки первого фактора — до любых проверок второго фактора.
Новый шаг DenyGroupsCheckingStep встраивается в пайплайн перед AccessGroupsCheckingStep.

### Валидация при старте адаптера:

Одновременное использование `deny-groups` и `access-groups` — параметры взаимоисключающие.
Пересечение `deny-groups` с другими групповыми параметрами — группа из `deny-groups` не может быть одновременно указана в `second-fa-groups`, `second-fa-bypass-groups`, `authentication-cache-groups` или `bypass-second-factor-when-api-unreachable-groups`. В сообщении об ошибке явно указывается конфликтующий параметр и группы.