### PR TITLE
DEV-1531 доработка Deny Groups

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/DenyGroupsCheck/DenyGroupsCheckingStep.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Application/Features/PacketHandler/UseCases/DenyGroupsCheck/DenyGroupsCheckingStep.cs
@@ -6,7 +6,7 @@ using Multifactor.Radius.Adapter.v2.Application.SharedPorts;
 
 namespace Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.DenyGroupsCheck;
 
-public class DenyGroupsCheckingStep : IRadiusPipelineStep
+internal sealed class DenyGroupsCheckingStep : IRadiusPipelineStep
 {
     private readonly ICheckMembership _checkMembership;
     private readonly ILogger<DenyGroupsCheckingStep> _logger;
@@ -34,23 +34,23 @@ public class DenyGroupsCheckingStep : IRadiusPipelineStep
         var domainInfo = context.ForestMetadata?.DetermineForestDomain(userIdentity);
         var denyGroups = context.LdapConfiguration.DenyGroups;
  
-        var isMember = context.LdapProfile.MemberOf.Intersect(denyGroups).Any();
-        if (isMember && !context.LdapConfiguration.LoadNestedGroups)
+        // Fast path: check flat MemberOf before querying nested groups
+        var matchedGroup = context.LdapProfile.MemberOf.Intersect(denyGroups).FirstOrDefault();
+        if (matchedGroup is not null && !context.LdapConfiguration.LoadNestedGroups)
         {
-            _logger.LogInformation(
-                "User '{user:l}' is a member of the Deny group in '{domain:l}'. Access rejected.",
-                context.RequestPacket.UserName, context.LdapConfiguration.ConnectionString);
+            LogDenied(context.RequestPacket.UserName, matchedGroup.ToString());
             return TerminatePipeline(context);
         }
  
         var request = MembershipDto.FromContext(context, denyGroups, domainInfo);
-        isMember = _checkMembership.Execute(request);
+        var isMember = _checkMembership.Execute(request);
  
         if (isMember)
         {
-            _logger.LogInformation(
-                "User '{user:l}' is a member of the Deny group in '{domain:l}'. Access rejected.",
-                context.RequestPacket.UserName, context.LdapConfiguration.ConnectionString);
+            // For nested groups we don't have the exact matched group name from ICheckMembership,
+            // so we report the configured deny groups for full context
+            var groupNames = string.Join(", ", denyGroups);
+            LogDenied(context.RequestPacket.UserName, groupNames);
             return TerminatePipeline(context);
         }
  
@@ -58,6 +58,13 @@ public class DenyGroupsCheckingStep : IRadiusPipelineStep
             "User '{user:l}' is not a member of any Deny group in '{domain:l}'. Access allowed to proceed.",
             context.RequestPacket.UserName, context.LdapConfiguration.ConnectionString);
         return Task.CompletedTask;
+    }
+ 
+    private void LogDenied(string userName, string groupName)
+    {
+        _logger.LogInformation(
+            "User '{user:l}' authentication failed. Denied by group '{group:l}'.",
+            userName, groupName);
     }
  
     private static Task TerminatePipeline(RadiusPipelineContext context)

--- a/src/Multifactor.Radius.Adapter.v2.Infrastructure/Configurations/Models/LdapServerConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Infrastructure/Configurations/Models/LdapServerConfiguration.cs
@@ -40,12 +40,6 @@ internal sealed class LdapServerConfiguration : ILdapServerConfiguration
         if (!string.IsNullOrWhiteSpace(ldapServerSection.IncludedSuffixes) && !string.IsNullOrWhiteSpace(ldapServerSection.ExcludedSuffixes))
             throw new InvalidConfigurationException($"Config name: '{fileName}', LDAP server: '{ldapServerSection.ConnectionString}'. Simultaneous use of 'included-suffixes' and 'excluded-suffixes' is not allowed.");
         
-        // Validate: deny-groups and access-groups cannot be used together
-        if (!string.IsNullOrWhiteSpace(ldapServerSection.DenyGroups) && !string.IsNullOrWhiteSpace(ldapServerSection.AccessGroups))
-            throw new InvalidConfigurationException(
-                $"Config name: '{fileName}', LDAP server: '{ldapServerSection.ConnectionString}'. " +
-                $"Simultaneous use of 'deny-groups' and 'access-groups' is not allowed.");
-        
         var parsedDenyGroups = ConfigurationValueParser.TryParseDistinguishedNames(ldapServerSection.DenyGroups, out var denyGroupsParsed)
             ? denyGroupsParsed
             : (IReadOnlyList<DistinguishedName>)[];

--- a/src/Multifactor.Radius.Adapter.v2.Infrastructure/Configurations/Models/LdapServerConfiguration.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Infrastructure/Configurations/Models/LdapServerConfiguration.cs
@@ -50,6 +50,7 @@ internal sealed class LdapServerConfiguration : ILdapServerConfiguration
             var otherGroups = new[]
             {
                 (ldapServerSection.SecondFaGroups, "second-fa-groups"),
+                (ldapServerSection.AccessGroups, "access-groups"),
                 (ldapServerSection.SecondFaBypassGroups, "second-fa-bypass-groups"),
                 (ldapServerSection.AuthenticationCacheGroups, "authentication-cache-groups"),
                 (ldapServerSection.BypassSecondFactorWhenApiUnreachableGroups, "bypass-second-factor-when-api-unreachable-groups")


### PR DESCRIPTION
### Что сделано:

1. Снято ограничение на совместное использование deny-groups и access-groups
2. Информативное логирование причины отказа:
`User 'john' authentication failed. Denied by group 'CN=Deny Users,OU=groups,DC=domain,DC=your'.`