### PR TITLE
DEV-1539 log API requests and response bodies in CreateAccessRequest

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.Infrastructure/Features/PacketHandler/UseCases/SecondFactor/CreateAccessRequest.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Infrastructure/Features/PacketHandler/UseCases/SecondFactor/CreateAccessRequest.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.SecondFactor.Multifactor.Exceptions;
@@ -33,10 +33,14 @@ internal sealed class CreateAccessRequest : ICreateAccessRequest
         
         var data = AccessRequestQuery.FromAppModel(dto);
         using var client = CreateClient(authData);
+
+        var requestJson = JsonSerializer.Serialize(data, _jsonOptions);
+        _logger.LogDebug("Sending request to API: {Request:l}", requestJson);
+
         try
         {
-            var response = await client.PostAsJsonAsync(Url,
-                data, _jsonOptions, cancellationToken);
+            using var requestContent = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync(Url, requestContent, cancellationToken);
             
             return await ProcessResponseAsync(response, cancellationToken);
         }
@@ -83,6 +87,9 @@ internal sealed class CreateAccessRequest : ICreateAccessRequest
         }
         
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        _logger.LogDebug("Received response from API: {Response:l}", content);
+
         var apiResponse = JsonSerializer.Deserialize<MultiFactorApiResponse<AccessRequestResponse>>(
             content, 
             _jsonOptions);

--- a/src/Multifactor.Radius.Adapter.v2.Infrastructure/Features/PacketHandler/UseCases/SecondFactor/SendChallengeAsync.cs
+++ b/src/Multifactor.Radius.Adapter.v2.Infrastructure/Features/PacketHandler/UseCases/SecondFactor/SendChallengeAsync.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Multifactor.Radius.Adapter.v2.Application.Features.PacketHandler.UseCases.SecondFactor.Multifactor.Exceptions;
@@ -31,11 +31,15 @@ internal sealed class SendChallenge: ISendChallenge
     {
         ArgumentNullException.ThrowIfNull(dto, nameof(dto));
         using var client = CreateClient(authData);
+        
+        var requestJson = JsonSerializer.Serialize(dto, _jsonOptions);
+        _logger.LogDebug("Sending request to API: {Request:l}", requestJson);
+
         try
         {
-            var response = await client.PostAsJsonAsync(Url,
-                dto, _jsonOptions, cancellationToken);
-            
+            using var requestContent = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync(Url, requestContent, cancellationToken);
+        
             return await ProcessResponseAsync(response, cancellationToken);
         }
         catch (HttpRequestException ex)
@@ -81,6 +85,9 @@ internal sealed class SendChallenge: ISendChallenge
         }
         
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        
+        _logger.LogDebug("Received response from API: {Response:l}", content);
+        
         var apiResponse = JsonSerializer.Deserialize<MultiFactorApiResponse<AccessRequestResponse>>(
             content, 
             _jsonOptions);


### PR DESCRIPTION
## Что сделано

Добавлено Debug-логирование исходящих запросов в Multifactor API и
ответов от него в `CreateAccessRequest` и `SendChallenge` — для упрощения диагностики.