### PR TITLE
DEV-1575: downgrade Multifactor.Core.Ldap 1.9.5 -> 1.9.4

### DIFF
--- a/src/Multifactor.Radius.Adapter.v2.Application/Multifactor.Radius.Adapter.v2.Application.csproj
+++ b/src/Multifactor.Radius.Adapter.v2.Application/Multifactor.Radius.Adapter.v2.Application.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="IPAddressRange" Version="6.3.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.5" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-      <PackageReference Include="Multifactor.Core.Ldap" Version="1.9.5" />
+      <PackageReference Include="Multifactor.Core.Ldap" Version="1.9.4" />
       <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
После обновления `Multifactor.Core.Ldap` до `1.9.5` перестала работать проверка вложенного членства в AD-группах `(AccessGroupsCheckingStep / LoadNestedGroups=true).`